### PR TITLE
[Endless] accountsservice.bst: Add extra_admin_groups to configuration

### DIFF
--- a/elements/core-deps/accountsservice.bst
+++ b/elements/core-deps/accountsservice.bst
@@ -18,6 +18,8 @@ depends:
 - freedesktop-sdk.bst:bootstrap-import.bst
 
 variables:
+  meson-local: >-
+    -Dextra_admin_groups=adm,systemd-journal
   meson: meson %{build-dir} */ %{meson-args}
   local_flags: >-
     -Wno-error=implicit-function-declaration


### PR DESCRIPTION
The user created by initial setup should be in all these groups "adm" & "systemd-journal", too. It uses the AccountsService D-Bus APIs to make the user & make it an administrator.

EOS adds groups "adm" and "systemd-journal" by following journalctl's description [1]:

All users are granted access to their private per-user journals. However, by default, only root and users who are members of a few special groups are granted access to the system journal and the journals of other users. Members of the groups "systemd-journal", "adm", and "wheel" can read all journal files. Note that the two latter groups traditionally have additional privileges specified by the distribution.

AC: Command "id" shows current user's groups. And, the user should be in "adm" and "systemd-journalctl" groups, too.

[1]: https://www.freedesktop.org/software/systemd/man/latest/journalctl.html

https://phabricator.endlessm.com/T31493
https://phabricator.endlessm.com/T35801