### PR TITLE
Rebase pam from EOS to GNOME OS

### DIFF
--- a/elements/freedesktop-sdk.bst
+++ b/elements/freedesktop-sdk.bst
@@ -5,6 +5,8 @@ sources:
   url: gitlab:freedesktop-sdk/freedesktop-sdk.git
   track: freedesktop-sdk-24.08*
   ref: freedesktop-sdk-24.08.16-0-g1986463a5e976d7eb101e8351ea7a5676d311f98
+- kind: patch_queue
+  path: patches/freedesktop-sdk
 
 config:
   options:

--- a/patches/freedesktop-sdk/Endless-linux-pam-Allow-weak-passwords.patch
+++ b/patches/freedesktop-sdk/Endless-linux-pam-Allow-weak-passwords.patch
@@ -1,0 +1,73 @@
+From f87652e89d5f3051f95245b1bed2e1f75e43b2f9 Mon Sep 17 00:00:00 2001
+From: Jian-Hong Pan <jhp@endlessos.org>
+Date: Tue, 15 Apr 2025 14:17:54 +0800
+Subject: [PATCH 1/3] [Endless] linux-pam: Allow weak passwords
+
+Allow weak passwords by dropping pam_pwquality.so module check and
+pam_unix.so's use_authtok. If pam_unix.so keeps use_authtok, the new
+password still have to pass pam_pwquality.so test [1]. Here is an
+example of dropped pam_pwquality.so module, but pam_unix.so keeping
+use_authtok. Passwd prints "Authentication token manipulation error"
+directly:
+
+$ passwd
+Changing password for dev.
+Current password:
+passwd: Authentication token manipulation error
+passwd: password unchanged
+
+Besides, the default nullok_secure [2] setting only allows passwordless
+accounts to access services like sudo and polkit from certain types of
+terminals. Instead, nullok is configured here because EOS would like
+passwordless accounts to be usable in all contexts, including terminal
+apps running in the desktop environment.
+
+AC:
+- Command "passwd" can change current user's password to 111.
+- When logged into the desktop of passwordless account, running
+  "sudo -s" in a Terminal gives a root shell without a password prompt.
+- When logged into the desktop of passwordless account, in Settings,
+  choosing Users then clicking Unlock unlocks the panel without a
+  password prompt.
+
+[1]: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/system-level_authentication_guide/pam_configuration_files#Sample_PAM_Configuration_Files
+[2]: https://manpages.debian.org/stretch/libpam-modules/pam_unix.8.en.html
+
+https://phabricator.endlessm.com/T14095
+https://phabricator.endlessm.com/T35802
+---
+ files/linux-pam-config/password-auth | 3 +--
+ files/linux-pam-config/system-auth   | 3 +--
+ 2 files changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/files/linux-pam-config/password-auth b/files/linux-pam-config/password-auth
+index a2803b492..1df8aac70 100644
+--- a/files/linux-pam-config/password-auth
++++ b/files/linux-pam-config/password-auth
+@@ -7,8 +7,7 @@ auth        required      pam_deny.so
+ account     required      pam_unix.so
+ 
+ -password   sufficient    pam_systemd_home.so
+-password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+-password    sufficient    pam_unix.so try_first_pass use_authtok nullok_secure sha512 shadow
++password    sufficient    pam_unix.so try_first_pass nullok sha512 shadow
+ password    required      pam_deny.so
+ 
+ -session    optional      pam_systemd_home.so
+diff --git a/files/linux-pam-config/system-auth b/files/linux-pam-config/system-auth
+index a2803b492..1df8aac70 100644
+--- a/files/linux-pam-config/system-auth
++++ b/files/linux-pam-config/system-auth
+@@ -7,8 +7,7 @@ auth        required      pam_deny.so
+ account     required      pam_unix.so
+ 
+ -password   sufficient    pam_systemd_home.so
+-password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+-password    sufficient    pam_unix.so try_first_pass use_authtok nullok_secure sha512 shadow
++password    sufficient    pam_unix.so try_first_pass nullok sha512 shadow
+ password    required      pam_deny.so
+ 
+ -session    optional      pam_systemd_home.so
+-- 
+2.49.0
+

--- a/patches/freedesktop-sdk/Endless-linux-pam-Enable-usergroups-for-private-user.patch
+++ b/patches/freedesktop-sdk/Endless-linux-pam-Enable-usergroups-for-private-user.patch
@@ -1,0 +1,79 @@
+From 31c080b4292ab01371ecf57ff4bfaba53af52564 Mon Sep 17 00:00:00 2001
+From: Jian-Hong Pan <jhp@endlessos.org>
+Date: Tue, 15 Apr 2025 17:03:25 +0800
+Subject: [PATCH 2/3] [Endless] linux-pam: Enable usergroups for private user
+ groups, the UMASK 0002
+
+With every user having their own group, the "historical" umask of 0022
+is excessively restrictive. For example, create an user account "user1"
+on GNOME OS current version. The user will have username "user1" in
+primary group "user1" but umask is 0022. The main disadvantage is that
+it prevents setting up shared directories for common access.
+
+To enable this type of shared directories, add the pam_umask module
+configured with usergroups=true so that the default umask becomes 0002
+(instead of 0022). Then, new files in shared directories can be read &
+written by the users in the same group.
+
+AC:
+- Command "umask" should output 0002.
+- 1. Have two users: user1 and user2 on the system.
+  2. Add user2 into user1's group "user1" by command:
+     "sudo usermod -aG user1 user2".
+  3. User1 creates a folder by command: "mkdir -p /tmp/test". Then,
+     create a dummy file into it by "touch /tmp/test/dummy.txt".
+  4. User1 logs out. And, login with user2. User2 should be able to
+     modify "/tmp/test/dummy.txt".
+
+https://phabricator.endlessm.com/T31847
+https://phabricator.endlessm.com/T35802
+https://github.com/endlessm/eos-build-meta/pull/2#discussion_r2050472931
+---
+ elements/components/linux-pam-base.bst | 1 +
+ files/linux-pam-config/password-auth   | 5 +++++
+ files/linux-pam-config/system-auth     | 5 +++++
+ 3 files changed, 11 insertions(+)
+
+diff --git a/elements/components/linux-pam-base.bst b/elements/components/linux-pam-base.bst
+index 0aa51500d..1148d37c4 100644
+--- a/elements/components/linux-pam-base.bst
++++ b/elements/components/linux-pam-base.bst
+@@ -17,6 +17,7 @@ variables:
+     -Dnis=disabled
+     -Dselinux=disabled
+     -Ddocs=disabled
++    -Dusergroups=true
+ 
+ config:
+   install-commands:
+diff --git a/files/linux-pam-config/password-auth b/files/linux-pam-config/password-auth
+index 1df8aac70..0e9e0f2a5 100644
+--- a/files/linux-pam-config/password-auth
++++ b/files/linux-pam-config/password-auth
+@@ -15,4 +15,9 @@ session     optional      pam_keyinit.so revoke
+ session     required      pam_limits.so
+ -session     optional      pam_systemd.so
+ session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
++# The pam_umask module will set the umask according to the system default in
++# /etc/login.defs and user settings, solving the problem of different
++# umask settings with different shells, display managers, remote sessions etc.
++# See "man pam_umask".
++session     optional      pam_umask.so
+ session     required      pam_unix.so
+diff --git a/files/linux-pam-config/system-auth b/files/linux-pam-config/system-auth
+index 1df8aac70..0e9e0f2a5 100644
+--- a/files/linux-pam-config/system-auth
++++ b/files/linux-pam-config/system-auth
+@@ -15,4 +15,9 @@ session     optional      pam_keyinit.so revoke
+ session     required      pam_limits.so
+ -session     optional      pam_systemd.so
+ session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
++# The pam_umask module will set the umask according to the system default in
++# /etc/login.defs and user settings, solving the problem of different
++# umask settings with different shells, display managers, remote sessions etc.
++# See "man pam_umask".
++session     optional      pam_umask.so
+ session     required      pam_unix.so
+-- 
+2.49.0
+

--- a/patches/freedesktop-sdk/Endless-linux-pam-Extend-env-PATH.patch
+++ b/patches/freedesktop-sdk/Endless-linux-pam-Extend-env-PATH.patch
@@ -1,0 +1,60 @@
+From 87c594400353fd9ced64fffaacdceddb22133af9 Mon Sep 17 00:00:00 2001
+From: Jian-Hong Pan <jhp@endlessos.org>
+Date: Tue, 15 Apr 2025 16:16:42 +0800
+Subject: [PATCH 3/3] [Endless] linux-pam: Extend env PATH
+
+EOS 6 (including before) extends env PATH with more paths:
+"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
+* Users can access commands in /usr/sbin and /sbin without full path. It
+  is useful for commands, such as reboot and poweroff.
+* Users may install applications into /usr/local/{bin, games, sbin}.
+
+GNOME OS provides env PATH as "/bin:/usr/bin" by default.
+* After check GNOME OS' filesystem, notice:
+  - /bin is linked to /usr/bin
+  - /sbin is linked to /usr/sbin
+  - /usr/sbin is linked to /usr/bin
+  Which means users already can access the commands in /usr/sbin and
+  /sbin without full path directly.
+* EOS has an immutable filesystem maintained by OSTree and /usr/games is
+  an empty directory.
+
+Consider the mentioned above, the new env PATH can be simplified as
+"/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/local/games" and
+extended by configuring /etc/environment.
+
+Note: "$HOME/.local/bin" will be prepended by shell automatically.
+
+AC: Command "printenv PATH"'s output should include
+"/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/local/games"
+
+https://phabricator.endlessm.com/T11289
+https://phabricator.endlessm.com/T35802
+---
+ elements/components/linux-pam-base.bst | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/elements/components/linux-pam-base.bst b/elements/components/linux-pam-base.bst
+index 1148d37c4..3cbe3fa51 100644
+--- a/elements/components/linux-pam-base.bst
++++ b/elements/components/linux-pam-base.bst
+@@ -22,7 +22,15 @@ variables:
+ config:
+   install-commands:
+     (>):
+-    - rm -rf "%{install-root}/var/run"
++    - |
++      rm -rf "%{install-root}/var/run"
++      # Add PATH to /etc/environment if it's not present there or in
++      # /etc/security/pam_env.conf
++      if ! grep -qs ^PATH "%{install-root}"/etc/security/pam_env.conf; then
++        if ! grep -qs ^PATH= "%{install-root}"/etc/environment; then
++          echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/local/games"' >> "%{install-root}"/etc/environment
++        fi
++      fi
+ 
+ public:
+   bst:
+-- 
+2.49.0
+


### PR DESCRIPTION
* freedesktop-sdk: Enable patching
* linux-pam: Allow weak passwords
* linux-pam: Enable usergroups for private user groups, the UMASK 0002
* linux-pam: Extend env PATH with more executable binary's folder

https://phabricator.endlessm.com/T35802