### PR TITLE
Draft: Add Shell extensions

### DIFF
--- a/elements/eos/blur-my-shell.bst
+++ b/elements/eos/blur-my-shell.bst
@@ -1,0 +1,10 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:aunetx/blur-my-shell.git
+  track: v*
+  ref: v68-2-0-25b200249400f45578947cc5ce8000e4abad3a4c
+
+depends:
+- gnome-build-meta.bst:core/gnome-shell.bst

--- a/elements/eos/dash-to-dock.bst
+++ b/elements/eos/dash-to-dock.bst
@@ -1,0 +1,10 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:micheleg/dash-to-dock.git
+  track: extensions.gnome.org-v*
+  ref: extensions.gnome.org-v101-0-g55489eed868dd42474e383b3fc2f47375de44896
+
+depends:
+- gnome-build-meta.bst:core/gnome-shell.bst

--- a/elements/eos/gnome-shell-extension-foresight.bst
+++ b/elements/eos/gnome-shell-extension-foresight.bst
@@ -1,0 +1,10 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:pesader/gnome-shell-extension-foresight.git
+  track: main
+  ref: 9351f7bba16b47ede45d2bfa42f620f23ff70874
+
+depends:
+- gnome-build-meta.bst:core/gnome-shell.bst

--- a/elements/eos/start-overlay-in-application-view.bst
+++ b/elements/eos/start-overlay-in-application-view.bst
@@ -1,0 +1,10 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:Hexcz/Start-Overlay-in-Application-View-for-Gnome-40-.git
+  track: main
+  ref: 544e1630556ab29f537c05bff765909b31f4b2eb
+
+depends:
+- gnome-build-meta.bst:core/gnome-shell.bst


### PR DESCRIPTION
This adds the GNOME Shell extensions used by Endless OS.

Fixes https://github.com/endlessm/eos-build-meta/issues/7

It is a work in progress and hasn't been tested yet, I opened this PR to share what I did so far.