### PR TITLE
Install eos-media, eos-meta and eos-theme

### DIFF
--- a/elements/core/meta-gnome-core-apps.bst
+++ b/elements/core/meta-gnome-core-apps.bst
@@ -19,3 +19,5 @@ depends:
 - gnome-build-meta.bst:core/nautilus.bst
 - gnome-build-meta.bst:core/simple-scan.bst
 - gnome-build-meta.bst:sdk/yelp.bst
+
+- eos/deps.bst

--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -1,0 +1,10 @@
+kind: stack
+description: |
+  Endless OS specific elements.
+
+  All additions on top of the base GNOME OS image are listed in this stack.
+
+depends:
+- eos/eos-media.bst
+- eos/eos-meta.bst
+- eos/eos-theme.bst

--- a/elements/eos/eos-media.bst
+++ b/elements/eos/eos-media.bst
@@ -1,0 +1,11 @@
+kind: meson
+description: Endless OS wallpaper.
+
+sources:
+- kind: git_repo
+  url: github:endlessm/eos-media.git
+  track: Release_*
+  ref: Release_6.0.7-0-g3f42869c4d20fe1343a43974ec1d3f2a0685ba3a
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst

--- a/elements/eos/eos-meta.bst
+++ b/elements/eos/eos-meta.bst
@@ -1,0 +1,10 @@
+kind: meson
+description: eos-meta provides Endless OS engineering scripts and mimeapps.list.
+
+sources:
+- kind: git_repo
+  url: github:endlessm/eos-meta.git
+  ref: 117079ba9747c0b758d4155bd1837a9f32615f9b
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst

--- a/elements/eos/eos-theme.bst
+++ b/elements/eos/eos-theme.bst
@@ -1,0 +1,23 @@
+kind: autotools
+description: |
+  Provides Endless OS theme.
+
+  * eos-default-settings: Default settings for Endless OS, including GSettings
+    overrides and X11 environment defaults, among others.
+  * eos-extra-faces: Extra avatar used by Endless OS.
+  * eos-extra-fonts: Extra fonts used by Endless applications.
+  * eos-icon-theme: Default icon theme used by Endless OS.
+  * eos-logos: Endless OS logos.
+
+sources:
+- kind: git_repo
+  url: github:endlessm/eos-theme.git
+  ref: 521a13fc801a911c0dd3e9802055eefe2e626cfe
+
+build-depends:
+- freedesktop-sdk.bst:components/systemd.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
+- gnome-build-meta.bst:core-deps/dconf.bst
+- gnome-build-meta.bst:sdk/glib.bst
+- gnome-build-meta.bst:sdk/gtk.bst
+- gnome-build-meta.bst:sdk/librsvg.bst


### PR DESCRIPTION
Install [eos-media](https://github.com/endlessm/eos-media), [eos-meta](https://github.com/endlessm/eos-build-meta/issues/34) and [eos-theme](https://github.com/endlessm/eos-build-meta/issues/37) into EOS 7.

eos-meta has not been released as a tag at latest commit.  So, refers to the commit hash directly temporally.

And, have `elements/eos` folder to gather EOS specific packages.

Fixes: https://github.com/endlessm/eos-build-meta/issues/32
Fixes: https://github.com/endlessm/eos-build-meta/issues/34
Fixes: https://github.com/endlessm/eos-build-meta/issues/37