### PR TITLE
Add Shell extensions

### DIFF
--- a/elements/core/gnome-session.bst
+++ b/elements/core/gnome-session.bst
@@ -1,0 +1,36 @@
+kind: meson
+
+sources:
+- kind: git_repo
+  url: gnome:gnome-session.git
+  track: main
+  ref: 49.alpha.1-1-g83410ba7d3e70b02bc8461e248ff15c9fa9a93ca
+- kind: patch
+  path: patches/gnome-session/0001-doc-skip-validation-of-xml.patch
+- kind: patch
+  path: patches/gnome-session/hide-gnome-session.patch
+- kind: local
+  path: files/gnome-session/endless-wayland.desktop
+
+build-depends:
+- freedesktop-sdk.bst:components/docbook-xsl.bst
+- freedesktop-sdk.bst:components/libxslt.bst
+- freedesktop-sdk.bst:components/xmlto.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+depends:
+- gnome-build-meta.bst:core-deps/upower.bst
+- gnome-build-meta.bst:core/gnome-desktop.bst
+- gnome-build-meta.bst:sdk/gtk.bst
+- gnome-build-meta.bst:sdk/json-glib.bst
+- freedesktop-sdk.bst:components/systemd.bst
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  meson-local: >-
+    -Dmimeapps=false
+
+config:
+  install-commands:
+    (>):
+    - install -Dm644 endless-wayland.desktop %{install-root}/usr/share/wayland-sessions/

--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -35,3 +35,6 @@ depends:
 # Used by eos-image-builder. This could move into a separate tree.
 # See: <https://github.com/endlessm/eos-build-meta/issues/81>
 - components/pigz.bst
+
+# GNOME Shell Extensions
+- eos/gnome-shell-extensions.bst

--- a/elements/eos/eos-theme.bst
+++ b/elements/eos/eos-theme.bst
@@ -12,7 +12,7 @@ description: |
 sources:
 - kind: git_repo
   url: github:endlessm/eos-theme.git
-  ref: 521a13fc801a911c0dd3e9802055eefe2e626cfe
+  ref: 27604966c939ce49532d1d868c0e14af18d0e45d
 
 build-depends:
 - freedesktop-sdk.bst:components/systemd.bst

--- a/elements/eos/gnome-shell-ext-auto-activities.bst
+++ b/elements/eos/gnome-shell-ext-auto-activities.bst
@@ -1,0 +1,19 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:CleoMenezesJr/auto-activities.git
+  track: main
+  ref: 6fc9381841cac0edbef5b7f6192a765c9426e7aa
+
+depends:
+- gnome-build-meta.bst:core/gnome-shell.bst
+
+config:
+  install-commands:
+    - |
+      DESTDIR=%{install-root} %{make-install}
+    - |
+      mkdir -p %{install-root}/usr/share/glib-2.0/schemas
+      cp schemas/org.gnome.shell.extensions.auto-activities.gschema.xml \
+        %{install-root}/usr/share/glib-2.0/schemas/

--- a/elements/eos/gnome-shell-ext-dash-to-dock.bst
+++ b/elements/eos/gnome-shell-ext-dash-to-dock.bst
@@ -1,0 +1,17 @@
+kind: make
+
+sources:
+- kind: git_repo
+  url: github:micheleg/dash-to-dock.git
+  track: extensions.gnome.org-v*
+  ref: extensions.gnome.org-v101-0-g55489eed868dd42474e383b3fc2f47375de44896
+
+depends:
+- freedesktop-sdk.bst:components/gettext.bst
+- gnome-build-meta.bst:sdk-deps/sassc.bst
+- gnome-build-meta.bst:core/gnome-shell.bst
+
+config:
+  install-commands:
+    - |
+      DESTDIR=%{install-root} %{make-install}

--- a/elements/eos/gnome-shell-ext-just-perfection.bst
+++ b/elements/eos/gnome-shell-ext-just-perfection.bst
@@ -1,0 +1,24 @@
+kind: manual
+
+sources:
+- kind: git_repo
+  url: gnome_gitlab:jrahmatzadeh/just-perfection.git
+  track: main
+  ref: 6da92ad9284c2ccb0232dc8f36a9cfef4d2d0eb2
+
+depends:
+- freedesktop-sdk.bst:components/gettext.bst
+- gnome-build-meta.bst:core/gnome-shell.bst
+
+config:
+  install-commands:
+  - ./scripts/build.sh -i
+  - mkdir -p %{install-root}/usr/share/gnome-shell/extensions/just-perfection-desktop@just-perfection/
+  - |
+    cp -Rf \
+      ~/.local/share/gnome-shell/extensions/just-perfection-desktop@just-perfection \
+      %{install-root}/usr/share/gnome-shell/extensions/
+  - |
+    mkdir -p %{install-root}/usr/share/glib-2.0/schemas
+    cp src/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml \
+      %{install-root}/usr/share/glib-2.0/schemas/

--- a/elements/eos/gnome-shell-ext-overlay-application-view.bst
+++ b/elements/eos/gnome-shell-ext-overlay-application-view.bst
@@ -1,0 +1,21 @@
+kind: manual
+
+sources:
+- kind: git_repo
+  url: github:Hexcz/Start-Overlay-in-Application-View-for-Gnome-40-.git
+  track: main
+  ref: 544e1630556ab29f537c05bff765909b31f4b2eb
+
+depends:
+- gnome-build-meta.bst:core/gnome-shell.bst
+
+config:
+  build-commands:
+  - gnome-extensions pack start-overlay-in-application-view\@Hex_cz
+  install-commands:
+  - gnome-extensions install --force start-overlay-in-application-view\@Hex_cz.shell-extension.zip
+  - mkdir -p %{install-root}/usr/share/gnome-shell/extensions/start-overlay-in-application-view@Hex_cz/
+  - |
+    cp -Rf \
+      ~/.local/share/gnome-shell/extensions/start-overlay-in-application-view@Hex_cz \
+      %{install-root}/usr/share/gnome-shell/extensions/

--- a/elements/eos/gnome-shell-ext-overview-background.bst
+++ b/elements/eos/gnome-shell-ext-overview-background.bst
@@ -1,0 +1,25 @@
+kind: manual
+
+sources:
+- kind: git_repo
+  url: github:howbea/overview-background.git
+  track: main
+  ref: c073d208aba56d1bbb387d67cd14a8bde2c87266
+
+depends:
+- gnome-build-meta.bst:core/gnome-shell.bst
+
+config:
+  build-commands:
+  - gnome-extensions pack overviewbackground\@github.com.orbitcorrection
+  install-commands:
+  - gnome-extensions install --force overviewbackground\@github.com.orbitcorrection.shell-extension.zip
+  - mkdir -p %{install-root}/usr/share/gnome-shell/extensions/overviewbackground@github.com.orbitcorrection/
+  - |
+    cp -Rf \
+      ~/.local/share/gnome-shell/extensions/overviewbackground@github.com.orbitcorrection \
+      %{install-root}/usr/share/gnome-shell/extensions/
+  - |
+    mkdir -p %{install-root}/usr/share/glib-2.0/schemas
+    cp overviewbackground@github.com.orbitcorrection/schemas/org.gnome.shell.extensions.ob.gschema.xml \
+      %{install-root}/usr/share/glib-2.0/schemas/

--- a/elements/eos/gnome-shell-extensions.bst
+++ b/elements/eos/gnome-shell-extensions.bst
@@ -1,0 +1,25 @@
+kind: manual
+
+depends:
+- eos/gnome-shell-ext-auto-activities.bst
+- eos/gnome-shell-ext-dash-to-dock.bst
+- eos/gnome-shell-ext-just-perfection.bst
+- eos/gnome-shell-ext-overlay-application-view.bst
+- eos/gnome-shell-ext-overview-background.bst
+
+config:
+  install-commands:
+    - mkdir -p %{install-root}/usr/share/gnome-shell/modes
+    - |
+      cat <<EOF > %{install-root}/usr/share/gnome-shell/modes/endless.json
+      {
+          "parentMode": "user",
+          "enabledExtensions": [
+            "auto-activities@CleoMenezesJr.github.io",
+            "dash-to-dock@micxgx.gmail.com",
+            "just-perfection-desktop@just-perfection",
+            "start-overlay-in-application-view@Hex_cz",
+            "overviewbackground@github.com.orbitcorrection"
+          ]
+      }
+      EOF

--- a/elements/gnome-build-meta.bst
+++ b/elements/gnome-build-meta.bst
@@ -9,4 +9,5 @@ sources:
 config:
   overrides:
     core/meta-gnome-core-apps.bst: core/meta-gnome-core-apps.bst
+    core/gnome-session.bst: core/gnome-session.bst
     freedesktop-sdk.bst: freedesktop-sdk.bst

--- a/files/gnome-session/endless-wayland.desktop
+++ b/files/gnome-session/endless-wayland.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Endless on Wayland
+Comment=This session logs you into Endless
+Exec=env GNOME_SHELL_SESSION_MODE=endless /usr/bin/gnome-session --session=gnome
+TryExec=/usr/bin/gnome-shell
+Type=Application
+DesktopNames=Endless:GNOME
+X-GDM-SessionRegisters=true

--- a/patches/gnome-session/0001-doc-skip-validation-of-xml.patch
+++ b/patches/gnome-session/0001-doc-skip-validation-of-xml.patch
@@ -1,0 +1,34 @@
+From 9939271a962e829131a4bebf115ac53b96b69098 Mon Sep 17 00:00:00 2001
+From: Abderrahim Kitouni <akitouni@gnome.org>
+Date: Fri, 30 May 2025 15:55:47 +0100
+Subject: [PATCH] doc: skip validation of xml
+
+xmllint from the latest release 2.14.3 doesn't considers the includes to be
+valid. Older releases (such as 2.12.x used by most distros) are fine. I don't
+know if this is a newly implemented check, or if it is buggy behaviour.
+---
+ doc/meson.build | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/doc/meson.build b/doc/meson.build
+index a03e2ea..9d7a53d 100644
+--- a/doc/meson.build
++++ b/doc/meson.build
+@@ -14,6 +14,7 @@ xmlto_searchpath = [
+ 
+ xmlto_command = [
+   find_program('xmlto'),
++  '--skip-validation',
+   '-o', '@OUTPUT@',
+   '--searchpath', ':'.join(xmlto_searchpath),
+   '-m', files('config.xsl'),
+@@ -38,4 +39,4 @@ custom_target(
+   depends: xml_dbus_docs,
+   install: true,
+   install_dir: session_datadir / 'doc' / meson.project_name()
+-)
+\ No newline at end of file
++)
+-- 
+2.49.0
+

--- a/patches/gnome-session/hide-gnome-session.patch
+++ b/patches/gnome-session/hide-gnome-session.patch
@@ -1,0 +1,45 @@
+From 500bc0a1f050df1223b5d2d17bfdba196cc952f9 Mon Sep 17 00:00:00 2001
+From: Zeeshan Ali Khan <zeenix@gmail.com>
+Date: Wed, 3 Sep 2025 18:00:23 +0200
+Subject: [PATCH] Hide GNOME sessions
+
+Hide the GNOME sessions (both Wayland and Xorg).
+
+https://phabricator.endlessm.com/T29401
+
+Based on a patch from Georges Basile Stavracas Neto <georges.stavracas@gmail.com>
+---
+ data/gnome-wayland.desktop.in.in | 1 +
+ data/gnome-xorg.desktop.in.in    | 1 +
+ data/gnome.desktop.in.in         | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/data/gnome-wayland.desktop.in.in b/data/gnome-wayland.desktop.in.in
+index b747802d..f58e5844 100644
+--- a/data/gnome-wayland.desktop.in.in
++++ b/data/gnome-wayland.desktop.in.in
+@@ -7,3 +7,4 @@ Type=Application
+ DesktopNames=GNOME
+ X-GDM-SessionRegisters=true
+ X-GDM-CanRunHeadless=true
++Hidden=true
+diff --git a/data/gnome-xorg.desktop.in.in b/data/gnome-xorg.desktop.in.in
+index 9a76fac8..7c31b430 100644
+--- a/data/gnome-xorg.desktop.in.in
++++ b/data/gnome-xorg.desktop.in.in
+@@ -6,3 +6,4 @@ TryExec=@bindir@/gnome-session
+ Type=Application
+ DesktopNames=GNOME
+ X-GDM-SessionRegisters=true
++Hidden=true
+diff --git a/data/gnome.desktop.in.in b/data/gnome.desktop.in.in
+index e3d4edaf..bb48d1cc 100644
+--- a/data/gnome.desktop.in.in
++++ b/data/gnome.desktop.in.in
+@@ -7,3 +7,4 @@ Type=Application
+ DesktopNames=GNOME
+ X-GDM-SessionRegisters=true
+ X-GDM-CanRunHeadless=@canrunheadless@
++Hidden=true
+--
+2.51.0


### PR DESCRIPTION
This adds the GNOME Shell extensions used by Endless OS.

Fixes #7