### PR TITLE
Update buildstream-plugins-community to 2.1.0

### DIFF
--- a/elements/plugins/buildstream-plugins-community.bst
+++ b/elements/plugins/buildstream-plugins-community.bst
@@ -4,5 +4,5 @@ kind: junction
 
 sources:
 - kind: tar
-  url: pypi:80/e7/e39284fab4c15cbace51dbcb1896529f0f4a3a1a769a204cf24df8d360e8/buildstream_plugins_community-2.0.2.tar.gz
-  ref: 778e8198661bea44944c505923ffd3c44fec24da5f7450cb5ce5b21871a9443c
+  url: pypi:ee/6c/3d749a2a9b481dec9a540fd239a1b289eab9c266bd53fe0d5b4d79186fa6/buildstream_plugins_community-2.1.0.tar.gz
+  ref: ce1b8bd4d63883e2937f6aba9afa8869660820c5fb0b26d739918c2103239406


### PR DESCRIPTION
This avoids a crash in the `git_repo` source plugin that happens when the Dulwich python library on the host is v0.24.1.

Example of the failure with buildstream-plugin-community 2.0.2 from job [47803527813](https://github.com/endlessm/eos-build-meta/actions/runs/16876769565/job/47803527813):

    eos/eos-keyring-base.bst:
    [00:00:00][][   fetch:eos/eos-keyring-base.bst      ] BUG     Fetch

        An unhandled exception occured:

        Traceback (most recent call last):
        ...
          File "/home/runner/_work/eos-build-meta/eos-build-meta/.bst/staged-junctions/plugins/buildstream-plugins-community.bst/e4d7c7a12733e2be824e8ebadf1836d653124d6fc17d672b0a27721a0637f78a/src/buildstream_plugins_community/sources/_git_utils.py", line 73, in collect_objects
            entry.commit for entry in mirror.get_walker(commit.id, excluded)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        TypeError: BaseRepo.get_walker() takes from 1 to 2 positional arguments but 3 were given