### PR TITLE
Introduce eos-kolibri.bst

### DIFF
--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -19,6 +19,7 @@ depends:
 
 # Endless additions to GNOME OS.
 - eos/eos-event-recorder-daemon.bst
+- eos/eos-kolibri.bst
 - eos/eos-media.bst
 - eos/eos-meta.bst
 - eos/eos-metrics.bst

--- a/elements/eos/eos-kolibri.bst
+++ b/elements/eos/eos-kolibri.bst
@@ -6,6 +6,8 @@ sources:
 - kind: git_repo
   url: github:endlessm/eos-kolibri.git
   ref: 544be49145ffac7481273814e3e3e24b13a2b223
+- kind: local
+  path: files/eos-kolibri/sysusers.d/kolibri.conf
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
@@ -21,3 +23,9 @@ runtime-depends:
 - gnome-build-meta.bst:sdk/glib.bst
 - gnome-build-meta.bst:sdk/gobject-introspection.bst
 - gnome-build-meta.bst:sdk/pygobject.bst
+
+config:
+  install-commands:
+    (>):
+      - mkdir -p "%{install-root}"/%{prefix}/lib/sysusers.d
+      - install -Dm644 ./kolibri.conf "%{install-root}"/%{prefix}/lib/sysusers.d/

--- a/elements/eos/eos-kolibri.bst
+++ b/elements/eos/eos-kolibri.bst
@@ -1,0 +1,23 @@
+kind: meson
+description: |
+  Tools and configuration to integrate the Kolibri flatpak with Endless OS.
+
+sources:
+- kind: git_repo
+  url: github:endlessm/eos-kolibri.git
+  ref: 544be49145ffac7481273814e3e3e24b13a2b223
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+depends:
+- freedesktop-sdk.bst:components/systemd.bst
+
+runtime-depends:
+- freedesktop-sdk.bst:components/flatpak.bst
+- freedesktop-sdk.bst:components/ostree.bst
+- freedesktop-sdk.bst:components/python3.bst
+- freedesktop-sdk.bst:components/python3-click.bst
+- gnome-build-meta.bst:sdk/glib.bst
+- gnome-build-meta.bst:sdk/gobject-introspection.bst
+- gnome-build-meta.bst:sdk/pygobject.bst

--- a/files/eos-kolibri/sysusers.d/kolibri.conf
+++ b/files/eos-kolibri/sysusers.d/kolibri.conf
@@ -1,0 +1,2 @@
+#Type Name     ID             GECOS
+u!    kolibri  132:139        "Kolibri"


### PR DESCRIPTION
Install eos-kolibri for tools and configuration to integrate the Kolibri flatpak with Endless OS.

Fixes: https://github.com/endlessm/eos-build-meta/issues/67