### PR TITLE
Add fscrypt to system

### DIFF
--- a/elements/eos/config/ostree.bst
+++ b/elements/eos/config/ostree.bst
@@ -37,6 +37,12 @@ config:
   - ln -s var/roothome "%{install-root}/root"
   - ln -s run/media "%{install-root}/media"
 
+  # Special undocumented support for encrypted file systems using fscrypt.
+  # In Endless OS, the root partition is mounted at `/sysroot/`. The files in
+  # `/` are put there by OSTree when it checks out a tree. This symlink helps
+  # fscrypt to find its state directory.
+  - ln -s sysroot/.fscrypt "%{install-root}/.fscrypt"
+
   - install -Dm644 -t "%{install-root}/usr/lib/tmpfiles.d" ostree.conf
 
 sources:

--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -13,6 +13,7 @@ depends:
 - eos/eos-keyring.bst
 - eos/grub.bst
 - freedesktop-sdk.bst:components/dracut.bst
+- freedesktop-sdk.bst:components/fscrypt.bst
 - freedesktop-sdk.bst:vm/boot/efi-ostree.bst
 
 # GNOME OS elements.


### PR DESCRIPTION
Should solve https://github.com/endlessm/eos-build-meta/issues/33

The symlink from `/.fscrypt` to `/sysroot/.fscrypt` is now present in the OSTree. I don't have an easy way to test this. It should be safe to land in main and we can see if it works from there.