### PR TITLE
Add Git to the base system

### DIFF
--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -18,6 +18,7 @@ depends:
 - gnome-build-meta.bst:gnomeos/os-release-user.bst
 
 # Endless additions to GNOME OS.
+- freedesktop-sdk.bst:components/git.bst
 - eos/eos-event-recorder-daemon.bst
 - eos/eos-kolibri.bst
 - eos/eos-media.bst


### PR DESCRIPTION
This is also included in the EOS6 base system, and seems to be required by eos-image-builder.