### PR TITLE
eos-kolibri.bst: Bump ref to c31e4183156b

### DIFF
--- a/elements/eos/eos-kolibri.bst
+++ b/elements/eos/eos-kolibri.bst
@@ -6,8 +6,6 @@ sources:
 - kind: git_repo
   url: github:endlessm/eos-kolibri.git
   ref: 544be49145ffac7481273814e3e3e24b13a2b223
-- kind: local
-  path: files/eos-kolibri/sysusers.d/kolibri.conf
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
@@ -23,9 +21,3 @@ runtime-depends:
 - gnome-build-meta.bst:sdk/glib.bst
 - gnome-build-meta.bst:sdk/gobject-introspection.bst
 - gnome-build-meta.bst:sdk/pygobject.bst
-
-config:
-  install-commands:
-    (>):
-      - mkdir -p "%{install-root}"/%{prefix}/lib/sysusers.d
-      - install -Dm644 ./kolibri.conf "%{install-root}"/%{prefix}/lib/sysusers.d/

--- a/elements/eos/eos-kolibri.bst
+++ b/elements/eos/eos-kolibri.bst
@@ -5,7 +5,7 @@ description: |
 sources:
 - kind: git_repo
   url: github:endlessm/eos-kolibri.git
-  ref: 544be49145ffac7481273814e3e3e24b13a2b223
+  ref: c31e4183156b5e780895d84ed84add99b41fa13b
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst

--- a/files/eos-kolibri/sysusers.d/kolibri.conf
+++ b/files/eos-kolibri/sysusers.d/kolibri.conf
@@ -1,2 +1,0 @@
-#Type Name     ID             GECOS
-u!    kolibri  132:139        "Kolibri"


### PR DESCRIPTION
Bump eos-kolibri ref to have fixed kolibri UID & GID defined by eos-kolibri directly.

Fixes: https://github.com/endlessm/eos-build-meta/issues/71