### PR TITLE
Initial build of GRUB

### DIFF
--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -11,6 +11,7 @@ depends:
 - eos/config/ostree.bst
 - eos/config/systemd-sysusers.bst
 - eos/eos-keyring.bst
+- eos/grub.bst
 - freedesktop-sdk.bst:components/dracut.bst
 - freedesktop-sdk.bst:vm/boot/efi-ostree.bst
 

--- a/elements/eos/grub.bst
+++ b/elements/eos/grub.bst
@@ -1,0 +1,11 @@
+kind: stack
+description: |
+  Stack containing the GRUB bootloader.
+
+  There are multiple builds of GRUB as the eos-image-builder
+  installs a UEFI and a legacy BIOS GRUB bootloader.
+
+depends:
+- eos/grub/grub-i386-pc.bst
+- eos/grub/grub-x86_64-efi.bst
+- eos/grub/grub-config.bst

--- a/elements/eos/grub/grub-common-sources.yml
+++ b/elements/eos/grub/grub-common-sources.yml
@@ -1,0 +1,32 @@
+# Sources list for GRUB.
+#
+# This is shared between the multiple elements that build GRUB, to
+# ensure everything is built from the same sources.
+
+sources:
+- kind: git_repo
+  url: github:endlessm/grub
+  track: master
+  # IMPORTANT: Ensure the SBAT metadata in `files/grub/` corresponds to
+  # the version of GRUB being shipped. Systems with UEFI Secure Boot can use
+  # the SBAT metadata to blocklist versions of GRUB with known vulnerabilities.
+  ref: 22484f8d7533afe7a0e175aed1b3fcfe035d84b2
+
+# This repo is a "source overlay" for GRUB, enabled via `GRUB_CONTRIB`.
+# We need the `grub-ntldr-img` program in eos-image-builder.
+- directory: grub-extras/
+  kind: git_repo
+  url: savannah:grub-extras.git
+  track: master
+  ref: 8a245d5c1800627af4cefa99162a89c7a46d8842
+
+- kind: git_module
+  path: gnulib
+  url: savannah:gnulib.git
+
+  # This ref of GNUlib is taken from bootstrap.conf in the 'master' branch
+  # of endlessm/grub.git.  The commit dates from 2019, rather futuristic in terms
+  # of GNU build system tools.
+  #
+  # See: <https://github.com/endlessm/grub/blob/master/bootstrap.conf>
+  ref: d271f868a8df9bbec29049d01e056481b7a1a263

--- a/elements/eos/grub/grub-config.bst
+++ b/elements/eos/grub/grub-config.bst
@@ -1,0 +1,26 @@
+kind: manual
+description: |
+  Configuration files for GRUB.
+
+  These are used by `grub-install` at bootloader install time.
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+variables:
+  strip-binaries: ''
+
+config:
+  install-commands:
+  - mkdir -p '%{install-root}/usr/lib/grub/conf/'
+  - install -Dm644 grub.cfg '%{install-root}/usr/lib/grub/conf/'
+  - install -Dm644 grub_embedded_bios.cfg '%{install-root}/usr/lib/grub/conf/'
+  - install -Dm644 grub_embedded_image.cfg '%{install-root}/usr/lib/grub/conf/'
+
+sources:
+- kind: local
+  path: files/grub-config/grub.cfg
+- kind: local
+  path: files/grub-config/grub_embedded_bios.cfg
+- kind: local
+  path: files/grub-config/grub_embedded_image.cfg

--- a/elements/eos/grub/grub-i386-pc.bst
+++ b/elements/eos/grub/grub-i386-pc.bst
@@ -1,0 +1,66 @@
+kind: autotools
+description: |
+  GRUB bootloader -- legacy BIOS version (i386-pc).
+
+  This builds an Endless-specific version of GRUB, adapted from the
+  `grub2-common` and `grub-pc` packages in the EOS6 build.
+
+  This element performs a standard install of GRUB into `/usr` which
+  is deployed in all EOS7 systems.
+
+  The `grub-install` program is also used by eos-image-builder when creating
+  the disk images.
+
+depends:
+- filename: freedesktop-sdk.bst:bootstrap-import.bst
+- filename: freedesktop-sdk.bst:components/bison.bst
+  type: build
+- filename: freedesktop-sdk.bst:components/flex.bst
+  type: build
+- filename: freedesktop-sdk.bst:components/git.bst
+  type: build
+- filename: freedesktop-sdk.bst:components/patch.bst
+  type: build
+- filename: freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
+  type: build
+
+variables:
+  autogen: >
+    ./bootstrap
+    --no-git
+    --gnulib-srcdir=%{build-root}/gnulib
+
+  conf-local: >
+    --with-platform=pc
+    --libdir=%{prefix}/lib
+    --libexecdir=%{prefix}/lib
+
+  # Enable selected extras from grub-extras.git.
+  grub-extras: "915resolution ntldr-img"
+
+  # Override the default Freedesktop SDK CFLAGS to disable things we can't use in GRUB:
+  #
+  #   * No control-flow protection as it doesn't work on i686
+  #   * No stack protector, it requires linking a library, but the bootloader is special
+  #   * Avoid certain -Werror build failures (this is an old version of GRUB)
+  configure: |
+    CFLAGS="$CFLAGS -fcf-protection=none -fno-stack-protector -Wno-error=maybe-uninitialized" %{conf-cmd} %{conf-args} %{conf-local}
+
+  # GRUB does its own stripping.
+  strip-binaries: ""
+
+environment:
+  GRUB_CONTRIB: ./grub-extras-enabled
+
+config:
+  configure-commands:
+    (<):
+      - |
+        mkdir ./grub-extras-enabled
+        for extra in %{grub-extras}; do
+          echo "Enabling grub-extra: $extra"
+          cp -a ./grub-extras/$extra ./grub-extras-enabled
+        done
+
+(@):
+- elements/eos/grub/grub-common-sources.yml

--- a/elements/eos/grub/grub-sources.yml
+++ b/elements/eos/grub/grub-sources.yml
@@ -1,0 +1,32 @@
+# Sources list for GRUB.
+#
+# This is shared between the multiple elements that build GRUB, to
+# ensure everything is built from the same sources.
+
+sources:
+- kind: git_repo
+  url: github:endlessm/grub
+  track: master
+  # IMPORTANT: Ensure the SBAT metadata in `files/grub/` corresponds to
+  # the version of GRUB being shipped. Systems with UEFI Secure Boot can use
+  # the SBAT metadata to blocklist versions of GRUB with known vulnerabilities.
+  ref: 22484f8d7533afe7a0e175aed1b3fcfe035d84b2
+
+# This repo is a "source overlay" for GRUB, enabled via `GRUB_CONTRIB`.
+# We need the `grub-ntldr-img` program in eos-image-builder.
+- directory: grub-extras/
+  kind: git_repo
+  url: savannah:grub-extras.git
+  track: master
+  ref: 8a245d5c1800627af4cefa99162a89c7a46d8842
+
+- kind: git_module
+  path: gnulib
+  url: savannah:gnulib.git
+
+  # This ref of GNUlib is taken from bootstrap.conf in the 'master' branch
+  # of endlessm/grub.git.  The commit dates from 2019, rather futuristic in terms
+  # of GNU build system tools.
+  #
+  # See: <https://github.com/endlessm/grub/blob/master/bootstrap.conf>
+  ref: d271f868a8df9bbec29049d01e056481b7a1a263

--- a/elements/eos/grub/grub-x86_64-efi.bst
+++ b/elements/eos/grub/grub-x86_64-efi.bst
@@ -1,0 +1,85 @@
+kind: autotools
+description: |
+  GRUB bootloader -- UEFI version (x86_64-efi).
+
+  This builds an Endless-specific version of GRUB, adapted from the
+  `grub-efi-amd64-image-signed` package in the EOS6 build.
+
+  The element builds a standalone UEFI binary of GRUB and installs it to
+  `/usr/lib/efi_binaries/` in the filesystem tree, and installed in the EFI
+  System Partition by eos-image-builder when creating disk images.
+
+depends:
+- filename: freedesktop-sdk.bst:bootstrap-import.bst
+- filename: freedesktop-sdk.bst:components/bison.bst
+  type: build
+- filename: freedesktop-sdk.bst:components/flex.bst
+  type: build
+- filename: freedesktop-sdk.bst:components/freetype.bst
+  type: build
+- filename: freedesktop-sdk.bst:components/git.bst
+  type: build
+- filename: freedesktop-sdk.bst:components/patch.bst
+  type: build
+- filename: freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
+  type: build
+
+variables:
+  autogen: >
+    ./bootstrap
+    --no-git
+    --gnulib-srcdir=%{build-root}/gnulib
+
+  conf-local: >
+    --with-platform=efi
+    --target=amd64-pe
+    --libdir=%{prefix}/lib
+    --libexecdir=%{prefix}/lib
+    --enable-grub-mkfont
+
+  # Override the default Freedesktop SDK CFLAGS to disable things we can't use in GRUB:
+  #
+  #   * No stack protector, it requires linking a library, but the bootloader is special
+  #   * Avoid certain -Werror build failures (this is an old version of GRUB)
+  configure: |
+    CFLAGS="$CFLAGS -fno-stack-protector -Wno-error=maybe-uninitialized" %{conf-cmd} %{conf-args} %{conf-local}
+  # GRUB does its own stripping.
+  strip-binaries: ""
+
+config:
+  build-commands:
+    (>):
+      # Build standalone UEFI executable.
+      #
+      # This step is adapted from the EOS6 GRUB package build.
+      - make unicode.pf2
+      - |
+        ./build-sa-efi-images \
+          grub-mkstandalone \
+          grub-core \
+          images/x86_64-efi/ \
+          x86_64-efi grubx64 \
+          grub_embedded_image.cfg \
+          $(pwd)/sbat.endless.csv
+
+  install-commands:
+    # Install standalone UEFI executable.
+    #
+    # This is used by `eos-image-builder`.
+    - |
+      mkdir -p %{install-root}/usr/lib/efi_binaries/EFI/endless/
+      install -Dm644 images/x86_64-efi/grubx64.efi %{install-root}/usr/lib/efi_binaries/EFI/endless/grubx64.efi
+
+(@):
+- elements/eos/grub/grub-common-sources.yml
+
+sources:
+  (>):
+    - kind: local
+      path: files/grub/sbat.endless.csv
+
+    - kind: local
+      path: files/grub/build-sa-efi-images
+
+    - kind: local
+      path: files/grub-config/grub_embedded_image.cfg

--- a/files/grub-config/grub.cfg
+++ b/files/grub-config/grub.cfg
@@ -1,0 +1,172 @@
+function load_video {
+  insmod all_video
+}
+
+function savedefault {
+    if test "$should_savedefault" ; then
+        saved_entry="${chosen}"
+        save_env -f $grubenv saved_entry
+    fi
+
+    if ! test "$eosimage" ; then
+        recordfail=1
+        save_env -f $grubenv recordfail
+    fi
+}
+
+if [ "x${timeout}" != "x-1" ]; then
+    if keystatus; then
+        if keystatus --shift; then
+            set timeout=-1
+        else
+            set timeout=0
+        fi
+    else
+        if sleep --interruptible 1 ; then
+            set timeout=0
+        fi
+    fi
+fi
+
+if test "$eosimage" ; then
+    set grubenv=($eosimage)/endless/grub/grubenv
+
+    # ISO
+    if test -f ($eosimage)/endless/endless.squash ; then
+        loopback loop_squash ($eosimage)/endless/endless.squash
+        loopback loop_img (loop_squash)/endless.img
+        set image_path="/endless/endless.squash"
+
+    # Dual boot
+    elif test -f ($eosimage)/endless/endless.img ; then
+        loopback loop_img ($eosimage)/endless/endless.img
+        set image_path="/endless/endless.img"
+    fi
+
+    set root=(loop_img,gpt3)
+    probe -u $eosimage --set=image_dev_uuid
+    set kparams="endless.image.device=UUID=$image_dev_uuid endless.image.path=$image_path nohibernate"
+
+    # test for Windows hibernation
+    if test -f ($eosimage)/hiberfil.sys ; then
+        if file --is-hibernated-hiberfil ($eosimage)/hiberfil.sys ; then
+            set hibernation=true
+        fi
+    fi
+
+    if test -f ($eosimage)/eosldr ; then
+        # If we can't boot Endless OS, provide a dummy Windows entry which
+        # reboots to the Windows boot menu.
+        if test "$hibernation" ; then
+            set found_windows=true
+            menuentry "Microsoft Windows" {
+                reboot
+            }
+        fi
+    elif test -f ($eosimage)/endless/live ; then
+        set kparams="$kparams endless.live_boot"
+        set is_live=true
+        export is_live
+    else
+        set should_savedefault=true
+        export should_savedefault
+
+        # search for other OSes
+        insmod regexp
+        for dev in ($bootdev,*); do
+            regexp -s device '\((.*)\)' $dev
+
+            if test "$grub_platform" == "efi"; then
+                if test -f ($device)/EFI/MICROSOFT/BOOT/BOOTMGFW.EFI ; then
+                    set found_windows=true
+                    menuentry "Microsoft Windows" $device {
+                        set booting_windows=true
+                        savedefault
+                        set root=$2
+                        chainloader ($root)/EFI/MICROSOFT/BOOT/BOOTMGFW.EFI
+                    }
+                fi
+            else
+                probe -s is_bootable -b ($device)
+                if test "$is_bootable" == "none"; then
+                    continue
+                fi
+
+                if test ( -f ($device)/bootmgr -a -f ($device)/Boot/BCD ) ; then
+                    set found_windows=true
+                    # Windows Vista or later
+                    menuentry "Microsoft Windows" $device {
+                        set booting_windows=true
+                        savedefault
+                        set root=$2
+                        chainloader +1
+                    }
+                elif test ( ( -f ($device)/ntldr -o -f ($device)/NTLDR ) -a ( -f ($device)/ntdetect.com -o -f ($device)/NTDETECT.COM ) -a ( -f ($device)/boot.ini -o -f ($device)/BOOT.INI ) ) ; then
+                    set found_windows=true
+                    # Windows XP
+                    menuentry "Microsoft Windows" $device {
+                        set booting_windows=true
+                        savedefault
+                        set root=$2
+                        regexp -s devnum 'hd([0-9]+)' $root
+                        if test "$devnum" != "0"; then
+                            drivemap -s hd0 $root
+                        fi
+                        chainloader +1
+                    }
+                elif test "$eosimage" ; then
+                    set found_windows=true
+                    # Other Windows flavour?
+                    menuentry "Unknown OS" $device {
+                        set booting_windows=true
+                        savedefault
+                        set root=$2
+                        chainloader +1
+                    }
+                fi
+            fi
+        done
+    fi
+else
+    probe -u $root --set=rootuuid
+    set grubenv=($root)/boot/grub/grubenv
+fi
+
+export grubenv
+
+if test -f $grubenv ; then
+    load_env -f $grubenv
+fi
+
+# load last selection. savedefault() only writes this entry on dual-boot
+# systems.
+if test "$saved_entry" ; then
+    set default="${saved_entry}"
+else
+    set default=0
+fi
+
+# Show menu if we need to offer Windows, or if the last boot failed.
+if test ( "$found_windows" -o "$recordfail" ) ; then
+    set timeout=30
+fi
+
+# Increment loglevel if the last boot failed.
+if test "$recordfail" ; then
+    set kparams="$kparams loglevel=6"
+fi
+
+if test "$hibernation"; then
+    menuentry "Endless OS (unavailable)" {
+        echo -------------------------------------------------------------
+        echo Endless OS is unavailable whilst Windows is hibernated.
+        echo Please select Windows and shut down or reboot to use Endless.
+        echo -------------------------------------------------------------
+        echo
+        echo Press ENTER to continue ...
+        read
+   }
+else
+    insmod blscfg
+    bls_import
+fi

--- a/files/grub-config/grub_embedded_bios.cfg
+++ b/files/grub-config/grub_embedded_bios.cfg
@@ -1,0 +1,2 @@
+search --set=root --label ostree --hint $bootdev,
+set prefix=($root)/boot/grub

--- a/files/grub-config/grub_embedded_image.cfg
+++ b/files/grub-config/grub_embedded_image.cfg
@@ -1,0 +1,12 @@
+# when booted from CDROM, $eosimage == $bootdev; otherwise, $eosimage == $bootdev,$partition
+
+search --set=eosimage --file --hint $bootdev, --quiet /endless/grub/grub.cfg
+if regexp "^$bootdev(|,.+)\$" "$eosimage"; then
+    set prefix=($eosimage)/endless/grub
+    export eosimage
+else
+    unset eosimage
+    search --set=root --label ostree --hint $bootdev,
+    set prefix=($root)/boot/grub
+fi
+normal $prefix/grub.cfg

--- a/files/grub/README.md
+++ b/files/grub/README.md
@@ -1,0 +1,17 @@
+# GRUB build inputs
+
+## SBAT metadata
+
+This directory contains the SBAT metadata for the GRUB bootloader used in
+Endless OS 7.
+
+SBAT is metadata format used in UEFI Secure Boot to identify bootloaders
+with known security vulnerabilities and blocklist them.
+
+The SBAT metadata needs to correspond with the version of GRUB built
+in the `eos/grub.bst` element.
+
+## Standalone UEFI images builder
+
+The `built-sa-efi-images` is taken from the EOS6 Debian package of GRUB:
+<https://github.com/endlessm/grub/blob/debian-master/debian/build-sa-efi-images>.

--- a/files/grub/build-sa-efi-images
+++ b/files/grub/build-sa-efi-images
@@ -1,0 +1,55 @@
+#! /bin/sh
+set -e
+
+if [ $# -lt 7 ]; then
+	echo "usage: $0 GRUB-MKSTANDALONE GRUB-CORE OUTPUT-DIRECTORY PLATFORM EFI-NAME CONF-NAME SBAT-CSV"
+	exit 1
+fi
+
+grub_mkstandalone="$1"
+grub_core="$2"
+outdir="$3"
+platform="$4"
+efi_name="$5"
+conf_name="$6"
+sbat_csv="$7"
+
+workdir=
+
+cleanup () {
+	[ -z "$workdir" ] || rm -rf "$workdir"
+}
+trap cleanup EXIT HUP INT QUIT TERM
+
+rm -rf "$outdir"
+mkdir -p "$outdir"
+
+workdir="$(mktemp -d build-sa-efi-images.XXXXXX)"
+
+# Standalone GRUB
+
+mkdir -p "$workdir/memdisk/boot/grub/fonts"
+
+cp "$conf_name" "$workdir/memdisk/boot/grub/grub.cfg"
+cp "$grub_core/../unicode.pf2" "$workdir/memdisk/boot/grub/fonts"
+
+# grub_mkstandalone is stupid so we must call it from inside memdisk directory
+
+grub_mkstandalone=$(pwd)/$grub_mkstandalone
+grub_core=$(pwd)/$grub_core
+outdir=$(pwd)/$outdir
+
+modules=
+modules="$modules all_video blscfg boot btrfs cat chain configfile disk echo efifwsetup efinet"
+modules="$modules ext2 exfat fat font gcry_sha512 gcry_rsa gettext gfxmenu gfxterm gfxterm_background gzio"
+modules="$modules halt hfsplus iso9660 jpeg keystatus loadenv loopback linux linuxefi"
+modules="$modules lsefi lsefimmap lsefisystab lssal memdisk minicmd normal ntfs"
+modules="$modules part_apple part_msdos part_gpt password_pbkdf2 png pgp probe read reboot regexp"
+modules="$modules search search_fs_uuid search_fs_file search_label search_fs_type"
+modules="$modules sleep test time true video file squash4 ls"
+
+( cd "$workdir/memdisk" && "$grub_mkstandalone" --modules="$modules" \
+	-d "$grub_core" -O "$platform" -o "$outdir/$efi_name.efi" \
+	--sbat="$sbat_csv" $(find -type f))
+
+exit 0

--- a/files/grub/sbat.endless.csv
+++ b/files/grub/sbat.endless.csv
@@ -1,4 +1,4 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
 grub,4,Free Software Foundation,grub,2.06,https://www.gnu.org/software/grub/
 grub.debian,4,Debian,grub2,2.06-13+deb12u1,https://tracker.debian.org/pkg/grub2
-grub.endless,4,Endless OS Foundation LLC,grub2,2.06+dev154.22484f8-7,https://github.com/endlessm/grub
+grub.endless,4,Endless OS Foundation LLC,grub2,2.06+dev154.22484f8-7bem1,https://github.com/endlessm/grub

--- a/files/grub/sbat.endless.csv
+++ b/files/grub/sbat.endless.csv
@@ -1,0 +1,4 @@
+sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+grub,4,Free Software Foundation,grub,2.06,https://www.gnu.org/software/grub/
+grub.debian,4,Debian,grub2,2.06-13+deb12u1,https://tracker.debian.org/pkg/grub2
+grub.endless,4,Endless OS Foundation LLC,grub2,2.06-13+deb12u1,https://github.com/endlessm/grub

--- a/files/grub/sbat.endless.csv
+++ b/files/grub/sbat.endless.csv
@@ -1,4 +1,4 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
 grub,4,Free Software Foundation,grub,2.06,https://www.gnu.org/software/grub/
 grub.debian,4,Debian,grub2,2.06-13+deb12u1,https://tracker.debian.org/pkg/grub2
-grub.endless,4,Endless OS Foundation LLC,grub2,2.06-13+deb12u1,https://github.com/endlessm/grub
+grub.endless,4,Endless OS Foundation LLC,grub2,2.06+dev154.22484f8-7,https://github.com/endlessm/grub

--- a/project.conf
+++ b/project.conf
@@ -214,3 +214,6 @@ junctions:
   internal:
   - plugins/buildstream-plugins.bst
   - plugins/buildstream-plugins-community.bst
+
+aliases:
+  savannah: https://git.savannah.gnu.org/git/


### PR DESCRIPTION
Two new elements to build GRUB, mirroring what the Debian package does for EOS6.

`grub-i386-pc.bst` provides the many "grub-common" tools, which end up
in the final system as with EOS6. It provides `grub-install`, used in
eos-image-builder to add BIOS boot support to the disk image.

`grub-x86_64-efi.bst` provides the standalone UEFI bootloader. It is
installed into `/usr/lib/efi_binaries` as in EOS6. The eos-image-builder
copies this to the EFI System Partition when building the disk image.

Both elements build the 'master' branch of <https://github.com/endlessm/grub>
which is the grub2_2.06-13+deb12u1 Debian tarball plus some Endless
patches.

The `grub-i386-pc.bst` element also builds two extras from
grub-extras[1] as done in the Endless Debian packaging.

This is enough for eos-image-builder to construct a bootable disk image.

Initial testing shows:

  * BIOS boot does not work. (And is possibly out of scope).
  * UEFI firmware with SecureBoot=0 is able to load Shim and then GRUB.
    At time of writing, boot fails somewhere later in the initramfs.
  * UEFI firmware with SecureBoot=1 loads GRUB, which raises an error
    "bad shim signature." This is expected: our kernel isn't signed.

All based on the EOS6 GRUB packaging from:
<https://github.com/endlessm/grub/blob/debian-master/debian/rules>

Part-of: https://github.com/endlessm/eos-build-meta/issues/8

1. https://git.savannah.gnu.org/git/grub-extras.git