### PR TITLE
Use the same ostree ref name everywhere

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
           branch: eos7
 
           build_element: eos/repo.bst
-          build_ref: "eos-buildstream"
+          build_ref: "os/eos/amd64/eos7"
 
           ostree_gpg_key_id: "00EA12D9A37DD2A7BD810643DFB958DC725AE7CA"
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ostree-gpg:
 files/ostree-config/eos.gpg: ostree-gpg
 	gpg --homedir=ostree-gpg --export --armor >"$@"
 
-OSTREE_BRANCH=eos-buildstream
+OSTREE_BRANCH=os/eos/amd64/eos7
 
 update-ostree: ostree-gpg files/ostree-config/eos.gpg
 	env BST="$(BST)" utils/update-repo.sh      \

--- a/elements/eos/repo.bst
+++ b/elements/eos/repo.bst
@@ -20,7 +20,7 @@ build-depends:
 
 variables:
   uuidnamespace: 731a6fa6-5071-4d7b-8e0d-b81a66a590bc
-  ostree-branch: "eos-buildstream"
+  ostree-branch: "os/eos/amd64/eos7"
 
 environment:
   OSTREE_REPO: "%{install-root}/ostree/repo"

--- a/utils/update-repo.sh
+++ b/utils/update-repo.sh
@@ -111,6 +111,7 @@ if [ "${new_commit}" != "${prev_commit}" ]; then
     fi
 
     ostree summary \
+           ${collection_id:+--add-metadata=ostree.deploy-collection-id='"'"${collection_id}"'"'} \
            ${gpg_opts[*]} \
            --update
 fi


### PR DESCRIPTION
This makes it easier to use local builds of eos7 as inputs to eos-image-builder. Nothing else should be affected.