### PR TITLE
Push EOS 7 build to EOS master OSTree branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,10 +131,10 @@ jobs:
         env:
           product: eos
           platform: amd64
-          branch: eos7
+          branch: master
 
           build_element: eos/repo.bst
-          build_ref: "os/eos/amd64/eos7"
+          build_ref: "os/eos/amd64/master"
 
           ostree_gpg_key_id: "00EA12D9A37DD2A7BD810643DFB958DC725AE7CA"
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ostree-gpg:
 files/ostree-config/eos.gpg: ostree-gpg
 	gpg --homedir=ostree-gpg --export --armor >"$@"
 
-OSTREE_BRANCH=os/eos/amd64/eos7
+OSTREE_BRANCH=os/eos/amd64/master
 
 update-ostree: ostree-gpg files/ostree-config/eos.gpg
 	env BST="$(BST)" utils/update-repo.sh      \

--- a/elements/eos/repo.bst
+++ b/elements/eos/repo.bst
@@ -20,7 +20,7 @@ build-depends:
 
 variables:
   uuidnamespace: 731a6fa6-5071-4d7b-8e0d-b81a66a590bc
-  ostree-branch: "os/eos/amd64/eos7"
+  ostree-branch: "os/eos/amd64/master"
 
 environment:
   OSTREE_REPO: "%{install-root}/ostree/repo"


### PR DESCRIPTION
Old EOS master OSTree build has been stopped [1]. Push the new EOS 7 OSTree build to EOS OSTree branch. Then, eos-imager-builder [2] can pull the latest OSTree commit to build new images.

[1]: https://github.com/endlessm/eos-build/pull/1571
[2]: https://github.com/endlessm/eos-image-builder

Part-of: https://github.com/endlessm/eos-build-meta/issues/13