### PR TITLE
Add "how to build" and "how to test" docs for image stage 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It also contains the Github Actions workflows that build official EOS builds.
 
 EOS7 has documentation in this repository, starting with this README.
 
-How to documentation for contributors:
+Tutorial documentation for contributors is in `doc/howto`:
 
   * [`doc/howto/build.md`](./doc/howto/build.md), how to build EOS7
   * [`doc/howto/test.md`](./doc/howto/test.md), how to test EOS7

--- a/doc/howto/build.md
+++ b/doc/howto/build.md
@@ -11,12 +11,10 @@ The EOS7 build process is split into two stages, and so is this guide:
   2. Image build (defined in [eos-image-builder.git](https://github.com/endlessm/eos-image-builder))
 
 In many cases you only need to run the ostree build, as you can test a new
-ostree build by deploying it as an update to an existing machine.
+ostree build by deploying it as an update to an existing machine, as documented
+in `doc/howto/test.md`.
 
-See [doc/howto/test.md](./test.md) for a guide to testing builds of the
-ostree and the image stages.
-
-## Building the OSTree stage
+## OSTree build stage
 
 ### Automated Builds
 
@@ -197,4 +195,59 @@ output.
 
 ## Image build stage
 
-To be written separately in https://github.com/endlessm/eos-build-meta/issues/104
+### Automated builds
+
+Image builds of 'master' run nightly in a private Jenkins instance. (If you
+have access, look for the job "nightly-master-pipeline").
+
+If the nightly job succeeds, it uploads images to a private file server at
+images.endless.org, under `/files/nightly/`.
+
+### Local builds
+
+#### Prerequisites
+
+You need a fast x86_64 machine with plenty of disk space and IO.
+
+Note that the eos-image-builder tool needs to run as the `root` user. It cannot
+run inside of container tools like Podman or Toolbox.
+
+#### Setup steps
+
+Clone [eos-image-builder.git](https://github.com/endlessm/eos-image-builder).
+
+Set up your `config/local.ini` file, which overrides the default image build
+config. There are some suggestions below for what to configure, and see also
+`config/local.ini.example` for more guidance.
+
+##### `[ostree]`
+
+If you're building an image from the 'master' ostree branch, leave the
+`[ostree]` settings as their defaults.
+
+If you built the ostree stage locally, configure eos-image-builder to
+pull from wherever it is -- here's an example pulling from `localhost`:
+
+    [ostree]
+    deploy_server_url = http://127.0.0.1:8000
+    pull_server_url = http://127.0.0.1:8000
+    dev_repo_path =
+    repo =
+
+You'll need to replace the GPG key in `data/keys` with the locally generated
+public key, exported as plain text with a `.asc` extension.
+
+Note that while you can put multiple keys in `data/keys`, only the last one
+will be used. The image builder maintains a repo in its cache, which embeds
+the public key. It won't update the cache if you change files in `data/keys`,
+you need to do that, or you'll see OSTree pull failures if you switch between
+local and CI builds.
+
+#### Build steps
+
+Run this command in the eos-image-builder.git clone:
+
+    sudo ./eos-image-builder
+
+On success, it will tell you where to find your new image. See
+`docs/howto/test.md` for a guide to testing.

--- a/doc/howto/test.md
+++ b/doc/howto/test.md
@@ -55,3 +55,39 @@ Reboot the machine to start the new version of EOS7.
 The `make ostree-serve` target runs `utils/run-local-repo.sh`. By default this
 uses a slow webserver built into Python. If `caddy` is available it'll use that
 and things will go much faster.
+
+## Testing the Image stage
+
+Image builds are under development. At time of writing you can test the following:
+
+  * Booting the disk image directly, from UEFI firmware with Secure Boot checks
+    disabled.
+
+The following is coming later:
+
+  * Booting the disk image directly, with UEFI Secure Boot checks enabled.
+  * Bootable media (live USBs), with option to install as the main OS.
+
+It's possible to test in a virtual machine, or on real hardware.
+
+### Virtual machines
+
+The following options are options you have for setting up virtual machines.
+
+1. Use QEMU directly. Some guidance on its many commandline options are
+   available in freedesktop-sdk
+   [BOOTABLE_IMAGES.md](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/BOOTABLE_IMAGES.md).
+2. Use libvirt and virt-manager.
+3. Use GNOME Boxes.
+
+Note that QEMU and libvirt will boot to an old-school BIOS firmware by default.
+You need to opt in explicitly to the newer TianoCore OMVF2 firmware which
+implements UEFI. GNOME Boxes defaults to UEFI.
+
+### Test steps
+
+1. Boot the disk image.
+
+2. Run through initial setup to create a user.
+
+3. Ensure the desktop works as you expect.


### PR DESCRIPTION
Part of https://github.com/endlessm/eos-build-meta/issues/104

Bear in mind the image testing will become more complicated as we progress https://github.com/endlessm/eos-build-meta/issues/8 due to Secure Boot work.