### PR TITLE
Patch Flatpak to avoid sandboxing extra_data scripts

### DIFF
--- a/elements/components/flatpak.bst
+++ b/elements/components/flatpak.bst
@@ -1,0 +1,52 @@
+# Copied from Freedesktop SDK 24.08.23 in order to patch Flatpak.
+
+kind: meson
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- freedesktop-sdk.bst:components/bison.bst
+- freedesktop-sdk.bst:components/docbook-xsl.bst
+- freedesktop-sdk.bst:components/xmlto.bst
+- freedesktop-sdk.bst:components/gettext.bst
+- freedesktop-sdk.bst:components/gobject-introspection.bst
+- freedesktop-sdk.bst:components/libxslt.bst
+- freedesktop-sdk.bst:components/python3-pyparsing.bst
+- freedesktop-sdk.bst:components/wayland-protocols.bst
+- freedesktop-sdk.bst:components/xmlto.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+- freedesktop-sdk.bst:components/bubblewrap.bst
+- freedesktop-sdk.bst:components/gpgme.bst
+- freedesktop-sdk.bst:components/libarchive.bst
+- freedesktop-sdk.bst:components/libxml2.bst
+- freedesktop-sdk.bst:components/curl.bst
+- freedesktop-sdk.bst:components/xorg-lib-xau.bst
+- freedesktop-sdk.bst:components/ostree.bst
+- freedesktop-sdk.bst:components/fuse3.bst
+- freedesktop-sdk.bst:components/json-glib.bst
+- freedesktop-sdk.bst:components/appstream.bst
+- freedesktop-sdk.bst:components/libseccomp.bst
+- freedesktop-sdk.bst:components/polkit.bst
+- freedesktop-sdk.bst:components/systemd-libs.bst
+- freedesktop-sdk.bst:components/xdg-dbus-proxy.bst
+
+
+variables:
+  meson-local: >-
+    -Dgtkdoc=disabled
+    -Dsystem_bubblewrap=bwrap
+    -Dhttp_backend=curl
+    -Ddconf=disabled
+    -Dmalcontent=disabled
+    -Dselinux_module=disabled
+    -Dtests=false
+    -Dsystem_dbus_proxy=xdg-dbus-proxy
+
+sources:
+- kind: git_repo
+  url: github:flatpak/flatpak.git
+  track: 1.1[02468]*
+  ref: 1.16.1-0-gb676905d91aa3c4e524ca663784d4cf085c465d7
+- kind: patch
+  path: patches/flatpak/revert-extra-data-sandbox.patch

--- a/elements/freedesktop-sdk.bst
+++ b/elements/freedesktop-sdk.bst
@@ -30,6 +30,7 @@ config:
     components/bash-config.bst: eos/config/bash-config.bst
     components/cups-base.bst: components/cups-base.bst
     components/dracut.bst: components/dracut.bst
+    components/flatpak.bst: components/flatpak.bst
     vm/config/sudo.bst: eos/config/sudo.bst
 
     # Overrides taken from gnome-build-meta

--- a/patches/flatpak/revert-extra-data-sandbox.patch
+++ b/patches/flatpak/revert-extra-data-sandbox.patch
@@ -1,0 +1,47 @@
+commit 7f6177f3c786ee8752069620453f5b3847301d7b (HEAD -> main)
+Author: Sam Thursfield <sam.thursfield@codethink.co.uk>
+Date:   Mon Sep 15 18:27:25 2025 +0200
+
+    Revert "dir: Document the apply_extra_data run flags"
+    
+    This reverts commit bbac52e6afafdd664461f3ca94f5a816afc46282.
+    
+    The given commit adds `FLATPAK_RUN_FLAG_SANDBOX` to the call used
+    to run the extra_data install program.
+    
+    In EOS7 image builds, this extra level of security is a problem as we
+    run flatpak installs inside a chroot which doesn't allow creating
+    user namespaces.
+
+diff --git a/common/flatpak-dir.c b/common/flatpak-dir.c
+index a4575128..deb8bc4d 100644
+--- a/common/flatpak-dir.c
++++ b/common/flatpak-dir.c
+@@ -8798,22 +8798,15 @@ apply_extra_data (FlatpakDir   *self,
+                           "--cap-drop", "ALL",
+                           NULL);
+ 
+-  /* Run flags which equal flatpak run --sandbox */
+-  run_flags = (FLATPAK_RUN_FLAG_SANDBOX |
++  /* Might need multiarch in apply_extra (see e.g. #3742).
++   * Should be pretty safe in this limited context */
++  run_flags = (FLATPAK_RUN_FLAG_MULTIARCH |
+                FLATPAK_RUN_FLAG_NO_SESSION_HELPER |
++               FLATPAK_RUN_FLAG_NO_PROC |
+                FLATPAK_RUN_FLAG_NO_SESSION_BUS_PROXY |
+                FLATPAK_RUN_FLAG_NO_SYSTEM_BUS_PROXY |
+                FLATPAK_RUN_FLAG_NO_A11Y_BUS_PROXY);
+ 
+-  /* Might need multiarch in apply_extra (see e.g. #3742).
+-   * Should be pretty safe in this limited context. */
+-  run_flags |= FLATPAK_RUN_FLAG_MULTIARCH;
+-
+-  /* This sandbox is run as root and /proc/self/exe can sometimes be used to
+-   * access outside files (see cd21428).
+-   * Disable /proc entirely in this context. */
+-  run_flags |= FLATPAK_RUN_FLAG_NO_PROC;
+-
+   if (!flatpak_run_setup_base_argv (bwrap, runtime_files, NULL, runtime_arch,
+                                     run_flags, error))
+     return FALSE;
+


### PR DESCRIPTION
This is due to a limitation in eos-image-builder. The `hooks/image/50-flatpak.chroot` image hook runs inside of `chroot()`, and uses libflatpak calls to install apps and runtimes. When run on an EOS7 buildroot, it fails with an error from `bwrap`, which is unable to create user namespaces inside the chroot, while trying to run an extra_data script. This worked with an EOS6 buildroot.

The limitation on creating user namespaces inside a chroot is hardcoded in Linux itself (see `create_user_ns()` in `kernel/user_namespaces.c`).

So the change must be that Flatpak previously ran the extra_data script without asking `bwrap` to create a user namespace.

See https://github.com/endlessm/eos-build-meta/issues/102.