### PR TITLE
CI: Force pip install Click 8.2.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
             ostree flatpak-builder
           python3 -m venv venv
           source venv/bin/activate
-          pip install BuildStream buildstream-plugins dulwich requests tomlkit
+          pip install BuildStream buildstream-plugins Click==8.2.1 dulwich requests tomlkit
 
       - name: Configure BuildStream
         run: |


### PR DESCRIPTION
CI runner installed BuildStream hits issue mentioned by "Fixes for Click 8.2 and 8.3" [1]. However, the fix has not been released, yet. So, force install Click 8.2.1 temporarily, until newer BuildStream version rolls out.

[1]: https://github.com/apache/buildstream/pull/2065

Fixes: https://github.com/endlessm/eos-build-meta/issues/121