### PR TITLE
Enable pam to decrypt encrypted home directory

### DIFF
--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -15,7 +15,7 @@ depends:
 - eos/eos-keyring.bst
 - eos/grub.bst
 - eos/initramfs.bst
-- freedesktop-sdk.bst:components/fscrypt.bst
+- eos/fscrypt.bst
 
 # GNOME OS elements.
 - gnome-build-meta.bst:gnomeos-deps/deps.bst

--- a/elements/eos/fscrypt.bst
+++ b/elements/eos/fscrypt.bst
@@ -1,0 +1,59 @@
+# Wrapper for freedesktop-sdk fscrypt element to fix PAM module location
+# and add configuration file
+kind: script
+
+build-depends:
+- freedesktop-sdk.bst:components/fscrypt.bst
+
+config:
+  commands:
+  # Debug: Check what we have from the fscrypt element
+  - |
+    echo "Looking for pam_fscrypt.so in the build environment:" >&2
+    find / -name "pam_fscrypt.so" 2>/dev/null || echo "No pam_fscrypt.so found!" >&2
+    echo "Looking for fscrypt binary:" >&2
+    find / -name "fscrypt" -type f -executable 2>/dev/null || echo "No fscrypt binary found!" >&2
+
+  # Copy only fscrypt-specific files
+  - |
+    # Copy the fscrypt binary
+    if [ -f /usr/bin/fscrypt ]; then
+      mkdir -p "%{install-root}%{bindir}"
+      cp /usr/bin/fscrypt "%{install-root}%{bindir}/"
+    fi
+
+  # Copy the PAM module to the correct multiarch location
+  - |
+    # First check where the PAM module is
+    PAM_MODULE=$(find /usr -name "pam_fscrypt.so" 2>/dev/null | head -1)
+    if [ -n "$PAM_MODULE" ]; then
+      echo "Found PAM module at: $PAM_MODULE" >&2
+      mkdir -p "%{install-root}%{libdir}/security"
+      cp "$PAM_MODULE" "%{install-root}%{libdir}/security/pam_fscrypt.so"
+      echo "Copied PAM module to %{install-root}%{libdir}/security/pam_fscrypt.so" >&2
+    else
+      echo "ERROR: pam_fscrypt.so not found in the build environment!" >&2
+    fi
+
+  # Install default fscrypt configuration
+  - |
+    mkdir -p "%{install-root}%{sysconfdir}"
+    cat > "%{install-root}%{sysconfdir}/fscrypt.conf" <<'EOF'
+    {
+      "source": "custom_passphrase",
+      "hash_costs": {
+        "time": 52,
+        "memory": 131072,
+        "parallelism": 32
+      },
+      "compatibility": "",
+      "options": {
+        "padding": "32",
+        "contents": "AES_256_XTS",
+        "filenames": "AES_256_CTS",
+        "policy_version": "2"
+      },
+      "use_fs_keyring_for_v1_policies": false,
+      "allow_cross_user_metadata": false
+    }
+    EOF

--- a/patches/freedesktop-sdk/Endless-linux-pam-fscrypt.patch
+++ b/patches/freedesktop-sdk/Endless-linux-pam-fscrypt.patch
@@ -31,7 +31,7 @@ index 0e9e0f2a5..1234567890 100644
  auth        required      pam_env.so
  -auth       sufficient    pam_systemd_home.so
  auth        sufficient    pam_unix.so try_first_pass nullok_secure
-+auth        optional      pam_fscrypt.so
++auth        optional      pam_fscrypt.so debug
  auth        required      pam_deny.so
 
  -account    sufficient    pam_systemd_home.so
@@ -47,7 +47,7 @@ index 0e9e0f2a5..1234567890 100644
  # See "man pam_umask".
  session     optional      pam_umask.so
  session     required      pam_unix.so
-+session     optional      pam_fscrypt.so drop_caches lock_policies
++session     optional      pam_fscrypt.so drop_caches lock_policies debug
 diff --git a/files/linux-pam-config/system-auth b/files/linux-pam-config/system-auth
 index 0e9e0f2a5..1234567890 100644
 --- a/files/linux-pam-config/system-auth
@@ -56,7 +56,7 @@ index 0e9e0f2a5..1234567890 100644
  auth        required      pam_env.so
  -auth       sufficient    pam_systemd_home.so
  auth        sufficient    pam_unix.so try_first_pass nullok_secure
-+auth        optional      pam_fscrypt.so
++auth        optional      pam_fscrypt.so debug
  auth        required      pam_deny.so
 
  -account    sufficient    pam_systemd_home.so
@@ -72,6 +72,6 @@ index 0e9e0f2a5..1234567890 100644
  # See "man pam_umask".
  session     optional      pam_umask.so
  session     required      pam_unix.so
-+session     optional      pam_fscrypt.so drop_caches lock_policies
++session     optional      pam_fscrypt.so drop_caches lock_policies debug
 --
 2.49.0

--- a/patches/freedesktop-sdk/Endless-linux-pam-fscrypt.patch
+++ b/patches/freedesktop-sdk/Endless-linux-pam-fscrypt.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zeeshan Ali Khan <zeenix@codethink.co.uk>
+Date: Tue, 24 Sep 2025 13:00:00 +0000
+Subject: [PATCH] [Endless] linux-pam: Add fscrypt support for home directory
+ encryption
+
+Add pam_fscrypt.so module to PAM configuration to enable automatic
+unlocking of fscrypt-encrypted home directories during login. This
+allows users with encrypted home directories to have them automatically
+decrypted using their login password.
+
+The pam_fscrypt module is added as optional to:
+- Auth stack: Captures the password during authentication.
+- Password stack: Updates fscrypt encryption when password changes.
+- Session stack: Manages encryption policies with drop_caches and
+  lock_policies options to properly clean up when sessions end.
+
+This patch must be applied after the other Endless PAM patches.
+
+https://github.com/endlessm/eos-build-meta/issues/33
+---
+ files/linux-pam-config/password-auth | 3 +++
+ files/linux-pam-config/system-auth   | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/files/linux-pam-config/password-auth b/files/linux-pam-config/password-auth
+index 0e9e0f2a5..1234567890 100644
+--- a/files/linux-pam-config/password-auth
++++ b/files/linux-pam-config/password-auth
+@@ -1,6 +1,7 @@
+ auth        required      pam_env.so
+ -auth       sufficient    pam_systemd_home.so
+ auth        sufficient    pam_unix.so try_first_pass nullok_secure
++auth        optional      pam_fscrypt.so
+ auth        required      pam_deny.so
+
+ -account    sufficient    pam_systemd_home.so
+@@ -8,6 +9,7 @@ account     required      pam_unix.so
+
+ -password   sufficient    pam_systemd_home.so
+ password    sufficient    pam_unix.so try_first_pass nullok sha512 shadow
++password    optional      pam_fscrypt.so
+ password    required      pam_deny.so
+
+ -session    optional      pam_systemd_home.so
+@@ -20,3 +22,4 @@ session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet
+ # See "man pam_umask".
+ session     optional      pam_umask.so
+ session     required      pam_unix.so
++session     optional      pam_fscrypt.so drop_caches lock_policies
+diff --git a/files/linux-pam-config/system-auth b/files/linux-pam-config/system-auth
+index 0e9e0f2a5..1234567890 100644
+--- a/files/linux-pam-config/system-auth
++++ b/files/linux-pam-config/system-auth
+@@ -1,6 +1,7 @@
+ auth        required      pam_env.so
+ -auth       sufficient    pam_systemd_home.so
+ auth        sufficient    pam_unix.so try_first_pass nullok_secure
++auth        optional      pam_fscrypt.so
+ auth        required      pam_deny.so
+
+ -account    sufficient    pam_systemd_home.so
+@@ -8,6 +9,7 @@ account     required      pam_unix.so
+
+ -password   sufficient    pam_systemd_home.so
+ password    sufficient    pam_unix.so try_first_pass nullok sha512 shadow
++password    optional      pam_fscrypt.so
+ password    required      pam_deny.so
+
+ -session    optional      pam_systemd_home.so
+@@ -20,3 +22,4 @@ session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet
+ # See "man pam_umask".
+ session     optional      pam_umask.so
+ session     required      pam_unix.so
++session     optional      pam_fscrypt.so drop_caches lock_policies
+--
+2.49.0


### PR DESCRIPTION
While fscrypt is already part of the target OS, we need to configure PAM to decrypt the home directory on login. This commit adds the PAM module installation and attempts to also enable it in the PAM configuration. However, it currently does not work. Something is a miss. :shrug: 