### PR TITLE
Secure boot in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,50 +44,13 @@ jobs:
             secret/ostree-builder/gpg/eoask1 private | OSTREE_BUILDER_GPG_PRIVATE ;
             secret/ostree-builder/ssh private | OSTREE_BUILDER_SSH_PRIVATE ;
 
-      - name: Write secrets
+      - name: Configure BuildStream
         run: |
           # Certificate for BuildStream cache
           echo "${ENDLESSCLIENT_CERT}" > client.crt
           echo "${ENDLESSCLIENT_CA_CHAIN}" >> client.crt
           echo "${ENDLESSCLIENT_KEY}" > client.key
           chmod 600 client.key
-          # Signing key for OSTree commits
-          mkdir ./ostree-gpg
-          chmod 700 ostree-gpg
-          echo "${OSTREE_BUILDER_GPG_PRIVATE}" | gpg --homedir ./ostree-gpg --import
-          # SSH key for OSTree pushes
-          echo "${OSTREE_BUILDER_SSH_PRIVATE}" > $HOME/.ssh/ostree_ssh
-          chmod 600 $HOME/.ssh/ostree_ssh
-
-      - name: Setup image version
-        run: |
-          build_num="${GITHUB_RUN_ID}"
-          if [ "${GITHUB_REF_NAME-}" = main ]; then
-            IMAGE_VERSION="nightly.$build_num"
-          else
-            # Assume this will always be a stable branch string like "gnome-44"
-            IMAGE_VERSION=$(echo "${GITHUB_REF_NAME:-unknown}.$build_num" | sed "s|/|_|g" | sed "s|-|_|g")
-          fi
-          echo "image-version: ${IMAGE_VERSION}" > include/image-version.yml
-          export IMAGE_VERSION
-          commit_time=$(git log -1 --format=format:%ct)
-          echo "filesystem-time: ${commit_time}" >> include/image-version.yml
-          cat include/image-version.yml
-
-      - name: Install BuildStream and dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            python3-pip python3-venv bubblewrap \
-            lzip xz-utils bzip2 gzip \
-            git wget curl \
-            ostree
-          python3 -m venv venv
-          source venv/bin/activate
-          pip install -r ./utils/requirements.txt
-
-      - name: Configure BuildStream
-        run: |
           source venv/bin/activate
           mkdir -p ~/.config
           cat > ~/.config/buildstream.conf << EOF
@@ -121,6 +84,33 @@ jobs:
                 client-key: $(pwd)/client.key
           EOF
 
+      - name: Setup image version
+        run: |
+          build_num="${GITHUB_RUN_ID}"
+          if [ "${GITHUB_REF_NAME-}" = main ]; then
+            IMAGE_VERSION="nightly.$build_num"
+          else
+            # Assume this will always be a stable branch string like "gnome-44"
+            IMAGE_VERSION=$(echo "${GITHUB_REF_NAME:-unknown}.$build_num" | sed "s|/|_|g" | sed "s|-|_|g")
+          fi
+          echo "image-version: ${IMAGE_VERSION}" > include/image-version.yml
+          export IMAGE_VERSION
+          commit_time=$(git log -1 --format=format:%ct)
+          echo "filesystem-time: ${commit_time}" >> include/image-version.yml
+          cat include/image-version.yml
+
+      - name: Install BuildStream and dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            python3-pip python3-venv bubblewrap \
+            lzip xz-utils bzip2 gzip \
+            git wget curl \
+            ostree
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r ./utils/requirements.txt
+
       - name: Enable unprivileged userns
         run: |
           source venv/bin/activate
@@ -153,6 +143,15 @@ jobs:
           push_repo: "eos"
         run: |
           push_ref="os/${product}/${platform}/${branch}"
+
+          echo "Signing key for OSTree commits"
+          mkdir ./ostree-gpg
+          chmod 700 ostree-gpg
+          echo "${OSTREE_BUILDER_GPG_PRIVATE}" | gpg --homedir ./ostree-gpg --import
+
+          echo "SSH key for OSTree pushes"
+          echo "${OSTREE_BUILDER_SSH_PRIVATE}" > $HOME/.ssh/ostree_ssh
+          chmod 600 $HOME/.ssh/ostree_ssh
 
           echo "Install ostree-push"
           sudo apt-get install -y gir1.2-ostree-1.0 openssh-client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           pki: |
             pki/issue/endless-client {"common_name": "github@endlessos.org", "ttl": "12h"} ;
 
-      - name: Fetch OSTree credentials from Vault
+      - name: Fetch signing credentials from Vault
         uses: hashicorp/vault-action@v3
         with:
           url: https://vault.endlessos.org
@@ -43,6 +43,8 @@ jobs:
           secrets: |
             secret/ostree-builder/gpg/eoask1 private | OSTREE_BUILDER_GPG_PRIVATE ;
             secret/ostree-builder/ssh private | OSTREE_BUILDER_SSH_PRIVATE ;
+            secret/secure-boot-signer/api-users/ostree-builder password | SBSIGNER_PASSWORD ;
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Configure BuildStream
         run: |
@@ -51,7 +53,6 @@ jobs:
           echo "${ENDLESSCLIENT_CA_CHAIN}" >> client.crt
           echo "${ENDLESSCLIENT_KEY}" > client.key
           chmod 600 client.key
-          source venv/bin/activate
           mkdir -p ~/.config
           cat > ~/.config/buildstream.conf << EOF
           # BuildStream user configuration
@@ -121,10 +122,38 @@ jobs:
           sccache: s3
       - uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Build root filesystem
+      - name: Build root filesystem (signed_boot=endless)
+        run: |
+          echo "Set up ~/.netrc"
+          cat >> ~/.netrc << EOF
+          machine sb-signer.endlessm-sf.com
+          login ostree-builder
+          password ${SBSIGNER_PASSWORD}
+          EOF
+          chmod 600 ~/.netrc
+
+          echo "Set up private key for eos-sb-signer"
+          echo "${OSTREE_BUILDER_GPG_PRIVATE}" > files/apitrustedkey.gpg
+          chmod 600 files/apitrustedkey.gpg
+
+          echo "Set up eos_sb_signer element plugin"
+          cat > include/eos_sb_signer.yml << EOF
+          elements:
+            eos_sb_signer:
+              config:
+                endpoint: https://sb-signer.endlessm-sf.com
+                private-key-file: files/apitrustedkey.gpg
+                timeout: 30
+          EOF
+          source venv/bin/activate
+          bst -o signed_boot endless build --retry-failed eos/repo.bst
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Build root filesystem (signed_boot=snakeoil)
         run: |
           source venv/bin/activate
-          bst build eos/repo.bst
+          bst -o signed_boot snakeoil build eos/repo.bst
+        if: ${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
 
       - name: Export OSTree commit and push it
         if: github.ref == 'refs/heads/main'
@@ -162,7 +191,7 @@ jobs:
 
           echo "Check out repo to a temporary directory"
           checkout="$(mktemp --suffix="-update-repo" -d -p "$(pwd)")"
-          ./venv/bin/bst artifact checkout --hardlinks "${build_element}" --directory "${checkout}"
+          ./venv/bin/bst -o signed_boot endless artifact checkout --hardlinks "${build_element}" --directory "${checkout}"
 
           commit="$(ostree --repo="${checkout}/ostree/repo" rev-parse "${build_ref}")"
           echo "Create a new OSTree repo and import commit ${commit}"


### PR DESCRIPTION
This PR updates the CI to use the `-o signed_boot endless` option for pushes to `main`. It uses `-o signed_boot snakeoil` for pull requests as before. This means that builds from `main` and only from `main` will now be signed with trusted Endless UEFI CA keys.

Testing this in a pull request is tricky, since it only runs on 'main'. A previous version ran on pull requests and you can see it working at: https://github.com/endlessm/eos-build-meta/actions/runs/18136755684/job/51617440433

Depends on https://github.com/endlessm/eos-build-meta/pull/145