### PR TITLE
plugins/eos_sb_signer: Use key fingerprint in cache key

### DIFF
--- a/plugins/eos_sb_signer.py
+++ b/plugins/eos_sb_signer.py
@@ -44,12 +44,13 @@ class EosSbSignerElement(Element):
             raise ElementError(f"Missing private key file {self.private_key_file}")
 
     def get_unique_key(self):
+        private_key, _ = PGPKey.from_file(self.private_key_file)
+        fingerprint = private_key.fingerprint
         key = {
             'input': self.input_path,
             'endpoint': self.endpoint,
             'output': self.output_path,
-            # FIXME: hash the file
-            'private-key-file': self.private_key_file,
+            'key-fingerprint': fingerprint,
         }
         return key
 


### PR DESCRIPTION
The `get_unique_key` function returns the factors that make an element unique. These are used to determine if the element build needs to run or if a cached build is suitable to use.

As a shortcut, I included the private key filename in the unique key, but this won't catch cases where the key is updated and the filename is not. Use the GPG fingerprint instead.

This does mean loading the private key file with `PGPy` on BuildStream startup. In local testing, the "Resolving elements" stage still took less than 1 second so this shouldn't be an issue.