### PR TITLE
PAYG: Install PAYG components for EOS OSTree

### DIFF
--- a/elements/eos/payg/deps.bst
+++ b/elements/eos/payg/deps.bst
@@ -2,12 +2,12 @@ kind: stack
 description: |
   All dependencies of PAYG features, if enabled.
 
-depends: []
+depends:
+- eos/payg/eos-payg.bst
+- eos/payg/eos-payg-nonfree.bst
 
 (?):
   - payg == true:
       depends:
         (>):
-          - eos/payg/eos-payg.bst
-          - eos/payg/eos-payg-nonfree.bst
           - eos/payg/uki-signed.bst

--- a/elements/eos/payg/eos-payg-nonfree.bst
+++ b/elements/eos/payg/eos-payg-nonfree.bst
@@ -19,3 +19,7 @@ sources:
   url: github:endlessm/eos-payg-nonfree
   track: master
   ref: Release_6.0.7-6-ge1a4545cf194cae4cd047d6896995764e6b6cdca
+
+variables:
+  meson-local: >-
+    -Dfactorylibexecdir=/usr/lib/eos-payg-nonfree

--- a/elements/eos/payg/eos-payg.bst
+++ b/elements/eos/payg/eos-payg.bst
@@ -25,3 +25,8 @@ sources:
   path: subprojects/libgsystemservice
   url: gnome_gitlab:pwithnall/libgsystemservice.git
   ref: 58468f2622e1415b5d1d2ffa06864ab31ab12c9a
+
+variables:
+  meson-local: >-
+    -Ddefault_library=both
+    -Dlibgsystemservice:default_library=static


### PR DESCRIPTION
Both EOS non-PAYG and PAYG system share the same OSTree branch. Which means they all have PAYG components. So, install eos-payg.bst and eos-payg-nonfree.bst directly. And, build eos-payg.bst and eos-payg-nonfree.bst by following current eos-payg & eos-payg-nonfree's build configuration.

Part-of: https://github.com/endlessm/eos-build-meta/pull/165