### PR TITLE
PAYG: Build eos-payg & eos-payg-nonfree with EOS 6 config

### DIFF
--- a/elements/eos/payg/eos-payg-nonfree.bst
+++ b/elements/eos/payg/eos-payg-nonfree.bst
@@ -19,3 +19,7 @@ sources:
   url: github:endlessm/eos-payg-nonfree
   track: master
   ref: Release_6.0.7-6-ge1a4545cf194cae4cd047d6896995764e6b6cdca
+
+variables:
+  meson-local: >-
+    -Dfactorylibexecdir=/usr/lib/eos-payg-nonfree

--- a/elements/eos/payg/eos-payg.bst
+++ b/elements/eos/payg/eos-payg.bst
@@ -25,3 +25,8 @@ sources:
   path: subprojects/libgsystemservice
   url: gnome_gitlab:pwithnall/libgsystemservice.git
   ref: 58468f2622e1415b5d1d2ffa06864ab31ab12c9a
+
+variables:
+  meson-local: >-
+    -Ddefault_library=both
+    -Dlibgsystemservice:default_library=static


### PR DESCRIPTION
Build eos-payg.bst and eos-payg-nonfree.bst by following current EOS 6 eos-payg & eos-payg-nonfree's build configuration.

Part-of: https://github.com/endlessm/eos-build-meta/pull/165