### PR TITLE
Install efitools.bst

### DIFF
--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -32,6 +32,7 @@ depends:
 - gnome-build-meta.bst:gnomeos-deps/toolbox.bst
 
 # Endless additions to GNOME OS.
+- freedesktop-sdk.bst:components/efitools.bst
 - freedesktop-sdk.bst:components/git.bst
 - eos/eos-event-recorder-daemon.bst
 - eos/eos-factory-tools.bst

--- a/elements/eos/payg/eos-payg-nonfree.bst
+++ b/elements/eos/payg/eos-payg-nonfree.bst
@@ -14,6 +14,9 @@ depends:
 - eos/payg/eos-payg.bst
 - eos/payg/libsodium.bst
 
+runtime-depends:
+- freedesktop-sdk.bst:components/efitools.bst
+
 sources:
 - kind: git_repo
   url: github:endlessm/eos-payg-nonfree


### PR DESCRIPTION
EOS PAYG needs cert-to-efi-sig-list and efi-updatevar provided by efitools. Besides, EOS system installs efitools on amd64 platform by default.

Fixes: https://github.com/endlessm/eos-build-meta/issues/198