### PR TITLE
eos-payg depends on dateutil module

### DIFF
--- a/elements/eos/payg/eos-payg.bst
+++ b/elements/eos/payg/eos-payg.bst
@@ -12,6 +12,9 @@ depends:
 - gnome-build-meta.bst:sdk/glib.bst
 - eos/payg/libpeas-1.bst
 
+runtime-depends:
+- eos/payg/python3-dateutil.bst
+
 sources:
 - kind: git_repo
   url: github:endlessm/eos-payg.git

--- a/elements/eos/payg/python3-dateutil.bst
+++ b/elements/eos/payg/python3-dateutil.bst
@@ -1,0 +1,19 @@
+kind: pyproject
+description: |
+  Useful extensions to the standard Python datetime features
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-python-setuptools.bst
+- freedesktop-sdk.bst:components/python3-setuptools-scm.bst
+
+depends:
+- freedesktop-sdk.bst:components/python3.bst
+
+runtime-depends:
+- freedesktop-sdk.bst:components/python3-six.bst
+
+sources:
+- kind: git_repo
+  url: github:dateutil/dateutil
+  track: '*.*.*'
+  ref: 2.9.0-0-gdb9d018944c41ddc740015cf5f64717c2ba64a5c


### PR DESCRIPTION
The eos-payg-ctl utility uses dateutil module.
```
$ eos-payg-ctl
Traceback (most recent call last):
  File "/usr/bin/eos-payg-ctl", line 26, in <module>
    from dateutil import tz
ModuleNotFoundError: No module named 'dateutil'
```
So, introduce python3-dateutil.bst and make eos-payg.bst depends on it.

Fixes: https://github.com/endlessm/eos-build-meta/issues/203