### PR TITLE
sign-kernel: Fix the signed kernel image deployment path

### DIFF
--- a/elements/signing/signed-kernel-endless.bst
+++ b/elements/signing/signed-kernel-endless.bst
@@ -15,12 +15,10 @@ config:
   # Output path for the signed kernel.
   output: "%{install-root}/boot/vmlinuz.signed"
 
-public:
-  initial-scripts:
-    script:
-      - |
-        echo "Installing signed kernel to location expected by OSTree."
-        sysroot="$1"
-        version="$(ls -1 /${sysroot}/usr/lib/modules | head -n1)"
-        mkdir -p "/${sysroot}/usr/lib/modules/${version}"
-        cp /boot/vmlinuz.signed "/${sysroot}/usr/lib/modules/${version}/vmlinuz"
+  install-commands:
+  - |
+    echo "Installing signed kernel to location expected by OSTree."
+    sysroot="$1"
+    version="$(ls -1 /${sysroot}/usr/lib/modules | head -n1)"
+    mkdir -p "${install-root}/usr/lib/modules/${version}"
+    cp "${install-root}/boot/vmlinuz.signed" "${install-root}/usr/lib/modules/${version}/vmlinuz"

--- a/elements/signing/signed-kernel-snakeoil.bst
+++ b/elements/signing/signed-kernel-snakeoil.bst
@@ -16,19 +16,15 @@ config:
         --cert VENDOR-snakeoil.crt \
         --output "%{install-root}/boot/vmlinuz.signed" \
         "/boot/vmlinuz"
+  - |
+    echo "Installing signed kernel to location expected by OSTree."
+    sysroot="$1"
+    version="$(ls -1 /${sysroot}/usr/lib/modules | head -n1)"
+    mkdir -p "%{install-root}/usr/lib/modules/${version}"
+    cp "%{install-root}/boot/vmlinuz.signed" "%{install-root}/usr/lib/modules/${version}/vmlinuz"
 
 sources:
 - kind: local
   path: files/boot-keys/VENDOR-snakeoil.key
 - kind: local
   path: files/boot-keys/VENDOR-snakeoil.crt
-
-public:
-  initial-scripts:
-    script:
-      - |
-        echo "Installing signed kernel to location expected by OSTree."
-        sysroot="$1"
-        version="$(ls -1 /${sysroot}/usr/lib/modules | head -n1)"
-        mkdir -p "/${sysroot}/usr/lib/modules/${version}"
-        cp /boot/vmlinuz.signed "/${sysroot}/usr/lib/modules/${version}/vmlinuz"


### PR DESCRIPTION
The bsts' public initial-scripts are not invoked. Then, the signed kernel image is not deployed into the expected which leads OSTree cannot find the kernel image when "ostree admin deploy". So, move the scripts to config's install-commands to fix the issue.

Fixes: 896d4d1e ("Move all repo setup into initial-scripts")
Fixes: https://github.com/endlessm/eos-build-meta/issues/208