### PR TITLE
sign-kernel: Aggregate installing signed kernel action as signed-kernel.bst

### DIFF
--- a/elements/eos/deps.bst
+++ b/elements/eos/deps.bst
@@ -67,12 +67,4 @@ depends:
 - eos/gnome-shell-extensions.bst
 
 # Signed kernel
-(?):
-  - signed_boot == "endless":
-      depends:
-        (>):
-          - signing/signed-kernel-endless.bst
-  - signed_boot == "snakeoil":
-      depends:
-        (>):
-          - signing/signed-kernel-snakeoil.bst
+- signing/signed-kernel.bst

--- a/elements/signing/signed-kernel-endless.bst
+++ b/elements/signing/signed-kernel-endless.bst
@@ -14,11 +14,3 @@ config:
 
   # Output path for the signed kernel.
   output: "%{install-root}/boot/vmlinuz.signed"
-
-  install-commands:
-  - |
-    echo "Installing signed kernel to location expected by OSTree."
-    sysroot="$1"
-    version="$(ls -1 /${sysroot}/usr/lib/modules | head -n1)"
-    mkdir -p "${install-root}/usr/lib/modules/${version}"
-    cp "${install-root}/boot/vmlinuz.signed" "${install-root}/usr/lib/modules/${version}/vmlinuz"

--- a/elements/signing/signed-kernel-snakeoil.bst
+++ b/elements/signing/signed-kernel-snakeoil.bst
@@ -16,12 +16,6 @@ config:
         --cert VENDOR-snakeoil.crt \
         --output "%{install-root}/boot/vmlinuz.signed" \
         "/boot/vmlinuz"
-  - |
-    echo "Installing signed kernel to location expected by OSTree."
-    sysroot="$1"
-    version="$(ls -1 /${sysroot}/usr/lib/modules | head -n1)"
-    mkdir -p "%{install-root}/usr/lib/modules/${version}"
-    cp "%{install-root}/boot/vmlinuz.signed" "%{install-root}/usr/lib/modules/${version}/vmlinuz"
 
 sources:
 - kind: local

--- a/elements/signing/signed-kernel.bst
+++ b/elements/signing/signed-kernel.bst
@@ -1,0 +1,29 @@
+kind: manual
+description: |
+  Install signed kernel to location expected by OSTree.
+
+build-depends:
+  - freedesktop-sdk.bst:bootstrap-import.bst
+  - components/linux.bst
+
+# Signed kernel
+(?):
+  - signed_boot == "endless":
+      build-depends:
+        (>):
+          - signing/signed-kernel-endless.bst
+  - signed_boot == "snakeoil":
+      build-depends:
+        (>):
+          - signing/signed-kernel-snakeoil.bst
+
+config:
+  install-commands:
+  - |
+    echo "Installing signed kernel to location expected by OSTree."
+    sysroot="$1"
+    version="$(ls -1 /${sysroot}/usr/lib/modules | head -n1)"
+    echo "version is ${version}"
+    mkdir -p %{install-root}/usr/lib/modules/${version}
+    cp /${sysroot}/boot/vmlinuz.signed %{install-root}/usr/lib/modules/${version}/vmlinuz
+    cp /${sysroot}/boot/config %{install-root}/usr/lib/modules/${version}/config


### PR DESCRIPTION
The signed-kernel-endless.bst element using eos_sb_signer plugin does not support install-commands. So, aggregate installing signed kernel action from signed-kernel-endless.bst and signed-kernel-snakeoil.bst as signed-kernel.bst. Then, deps.bst can depends on signed-kernel.bst directly.

Fixes: 09276daf5deb ("sign-kernel: Fix the signed kernel image deployment path")
Fixes: https://github.com/endlessm/eos-build-meta/issues/208