### PR TITLE
Update kernel, eos-updater and eos-payg-nonfree

### DIFF
--- a/elements/eos/eos-updater.bst
+++ b/elements/eos/eos-updater.bst
@@ -11,7 +11,7 @@ sources:
 - kind: git_repo
   url: github:endlessm/eos-updater.git
   track: Release_*
-  ref: Release_6.0.7-0-gab693943203082ab01adc68751ca91c38c7c3233
+  ref: Release_6.0.11-0-gdf81cf7f9688e03553736b06060f1bd71e54c97d
 
 build-depends:
 - freedesktop-sdk.bst:components/avahi.bst

--- a/elements/eos/payg/eos-payg-nonfree.bst
+++ b/elements/eos/payg/eos-payg-nonfree.bst
@@ -13,6 +13,8 @@ build-depends:
 depends:
 - eos/payg/eos-payg.bst
 - eos/payg/libsodium.bst
+- freedesktop-sdk.bst:components/curl.bst
+- freedesktop-sdk.bst:components/openssl.bst
 
 runtime-depends:
 - freedesktop-sdk.bst:components/efitools.bst
@@ -21,7 +23,7 @@ sources:
 - kind: git_repo
   url: github:endlessm/eos-payg-nonfree
   track: master
-  ref: Release_6.0.7-8-g4dc4892a7fad5129324f279a9a1e702f178d7e9a
+  ref: 4c4749b7d97438e4186267e6da25dffa5699efc8
 
 variables:
   meson-local: >-

--- a/elements/include/linux.yml
+++ b/elements/include/linux.yml
@@ -6,7 +6,7 @@ sources:
   track: master
   exclude:
   - '*-rc*'
-  ref: 8438fb3d672d9a855de888f3dab81f7f24c95789
+  ref: Release_6.0.11-0-g68faae5cc8fe736a8454c19c0cc88fce53b629cd
 # Override: Our patches are completely different from the upstream ones, no need
 # to update them.
 - kind: patch_queue


### PR DESCRIPTION
EOS 6.0.11 has been released.  So, update related elements to the new one.